### PR TITLE
Fixes an undefined symbol.

### DIFF
--- a/mongo.c
+++ b/mongo.c
@@ -1419,7 +1419,7 @@ PHP_METHOD(Mongo, switchSlave) {
     return;
   }
 
-  mongo_util_rs_get_ping(link TSRMLS_CC);
+  mongo_util_rs_ping(link TSRMLS_CC);
   if (set_a_slave(link, &errmsg) == FAILURE) {
     if (!EG(exception)) {
       if (errmsg) {


### PR DESCRIPTION
Fixes an undefined symbol when trying to call "mongo_util_rs_get_ping" by renaming to "mongo_util_rs_ping".
