### PR TITLE
Added a method, readFile, to MongoGridFSFile

### DIFF
--- a/gridfs.h
+++ b/gridfs.h
@@ -35,6 +35,7 @@ PHP_METHOD(MongoGridFSFile, getFilename);
 PHP_METHOD(MongoGridFSFile, getSize);
 PHP_METHOD(MongoGridFSFile, write);
 PHP_METHOD(MongoGridFSFile, getBytes);
+PHP_METHOD(MongoGridFSFile, readFile);
 
 PHP_METHOD(MongoGridFSCursor, __construct);
 PHP_METHOD(MongoGridFSCursor, getNext);


### PR DESCRIPTION
Mainly a copy of getBytes, except that it echos the file out instead of storing in a string. Potentially useful for large objects.

Haven't written any extension code in a long time, and don't know much about the Mongo driver; but I wanted to contribute, and I figured a proof-of-concept patch might get more traction than a simple request. :) Thanks for reading.
