### PR TITLE
Fix for PHP-202, Too many open files

### DIFF
--- a/util/connect.h
+++ b/util/connect.h
@@ -24,7 +24,7 @@
   closesocket(socket);                                          \
   WSACleanup();
 #else
-#define MONGO_UTIL_DISCONNECT(socket) shutdown((socket), 2);
+#define MONGO_UTIL_DISCONNECT(socket) shutdown((socket), 2); close(socket);
 #endif
 
 /**


### PR DESCRIPTION
After being hit by https://jira.mongodb.org/browse/PHP-202 last week, I came up with my own patch.

Basically, none of the connection pool file descriptors seem to be released by the driver, even if the connections fail. If a single mongo server in the connection pool goes offline, the server running php quickly piles up socket descriptors from failed connections, then mongo connections start timing out, then, Kaboom :)

Disclaimer: I don't actually know what I'm doing, but this patch worked for me and I hope it's useful for fixing the bug.

Cheers,
Carlos
