### PR TITLE
(PHP-79) Added stream support for GridFS 

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -5,7 +5,7 @@ PHP_MONGO_CFLAGS="-I@ext_builddir@/util"
 
 if test "$PHP_MONGO" != "no"; then
   AC_DEFINE(HAVE_MONGO, 1, [Whether you have Mongo extension])
-  PHP_NEW_EXTENSION(mongo, php_mongo.c mongo.c mongo_types.c bson.c cursor.c collection.c db.c gridfs.c util/hash.c util/connect.c util/pool.c util/rs.c util/link.c util/server.c util/log.c util/io.c util/parse.c, $ext_shared,, $PHP_MONGO_CFLAGS)
+  PHP_NEW_EXTENSION(mongo, php_mongo.c mongo.c mongo_types.c bson.c cursor.c collection.c db.c gridfs.c gridfs_stream.c util/hash.c util/connect.c util/pool.c util/rs.c util/link.c util/server.c util/log.c util/io.c util/parse.c, $ext_shared,, $PHP_MONGO_CFLAGS)
 
   PHP_ADD_BUILD_DIR([$ext_builddir/util], 1)
   PHP_ADD_INCLUDE([$ext_builddir/util])

--- a/gridfs.c
+++ b/gridfs.c
@@ -88,6 +88,8 @@ static int setup_file_fields(zval *zfile, char *filename, int size TSRMLS_DC);
 static int insert_chunk(zval *chunks, zval *zid, int chunk_num, char *buf, int chunk_size, zval *options TSRMLS_DC);
 static void ensure_gridfs_index(zval *return_value, zval *this_ptr TSRMLS_DC);
 
+php_stream * gridfs_stream_init(zval * file_object);
+
 PHP_METHOD(MongoGridFS, __construct) {
   zval *zdb, *files = 0, *chunks = 0, *zchunks;
 
@@ -981,6 +983,18 @@ PHP_METHOD(MongoGridFSFile, write) {
   RETURN_LONG(total);
 }
 
+PHP_METHOD(MongoGridFSFile, getResource) {
+    php_stream * stream;
+
+    stream = gridfs_stream_init(getThis());
+    if (!stream || stream == FAILURE) {
+        zend_throw_exception(mongo_ce_GridFSException, "couldn't create a php_stream", 0 TSRMLS_CC);
+        return;
+    }
+
+    php_stream_to_zval(stream, return_value);
+}
+
 PHP_METHOD(MongoGridFSFile, getBytes) {
   zval *file, *gridfs, *chunks, *query, *cursor, *sort, *temp;
   zval **id, **size;
@@ -1117,6 +1131,7 @@ static zend_function_entry MongoGridFSFile_methods[] = {
   PHP_ME(MongoGridFSFile, getSize, NULL, ZEND_ACC_PUBLIC)
   PHP_ME(MongoGridFSFile, write, NULL, ZEND_ACC_PUBLIC)
   PHP_ME(MongoGridFSFile, getBytes, NULL, ZEND_ACC_PUBLIC)
+  PHP_ME(MongoGridFSFile, getResource, NULL, ZEND_ACC_PUBLIC)
   {NULL, NULL, NULL}
 };
 

--- a/gridfs_stream.c
+++ b/gridfs_stream.c
@@ -1,0 +1,365 @@
+/* gridfs_stream.c */
+/**
+ *  Copyright 2009-2011 10gen, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+/* Author: César D. Rodas <crodas@php.net> */
+#include <php.h>
+#ifdef WIN32
+#ifndef int64_t
+	 typedef __int64 int64_t;
+#  endif
+#endif
+
+#include <php_globals.h>
+#include <ext/standard/file.h>
+#include <ext/standard/flock_compat.h>
+#ifdef HAVE_SYS_FILE_H
+#   include <sys/file.h>
+#endif
+
+#include <zend_exceptions.h>
+
+#include "php_mongo.h"
+#include "gridfs.h"
+#include "collection.h"
+#include "cursor.h"
+#include "mongo_types.h"
+#include "db.h"
+
+extern zend_class_entry
+	*mongo_ce_BinData,
+	*mongo_ce_GridFS,
+	*mongo_ce_GridFSFile,
+	*mongo_ce_GridFSException;
+
+ZEND_EXTERN_MODULE_GLOBALS(mongo);
+
+static size_t gridfs_read(php_stream *stream, char *buf, size_t count TSRMLS_DC);
+static int gridfs_close(php_stream *stream, int close_handle TSRMLS_DC);
+static int gridfs_stat(php_stream *stream, php_stream_statbuf *ssb TSRMLS_DC);
+static int gridfs_option(php_stream *stream, int option, int value, void *ptrparam TSRMLS_DC);
+static int gridfs_seek(php_stream *stream, off_t offset, int whence, off_t *newoffs TSRMLS_DC);
+
+typedef struct _gridfs_stream_data {
+	zval * fileObj; /* MongoGridFSFile Object */
+	zval * chunkObj; /* Chunk collection object */
+	zval * id; /* File ID  */
+	zval * query; /* Query array */
+
+	/* file current position */
+	size_t offset;
+
+	/* file size */
+	int size;
+
+	/* Chunk and Buffer {{{ */
+	/* chunk size */
+	int chunkSize;
+	int totalChunks;
+
+	/* which chunk is loaded? */
+	int chunkId;
+
+
+	/* mongo current chunk is kept in memory */
+	unsigned char * buffer;
+
+	/* chunk size */
+	int buffer_size;
+
+	/* where we are in the chunk? */
+	size_t buffer_offset;
+
+	 /* }}} */
+
+} gridfs_stream_data;
+
+php_stream_ops gridfs_stream_ops = {
+	NULL, /* write */
+	gridfs_read, /* read */
+	gridfs_close, /* close */
+	NULL, /* flush */
+	"gridfs-wrapper",
+	gridfs_seek, /* seek */
+	NULL, /* cast */
+	gridfs_stat, /* stat */
+	gridfs_option, /* set_option */
+};
+
+/* some handy macros {{{ */
+#ifndef MIN
+#   define MIN(a, b) a > b ? b : a
+#endif
+
+#if 0
+#   define DEBUG(x)  printf x;fflush(stdout);
+#else
+#   define DEBUG(x)
+#endif
+
+#define READ_ARRAY_PROP(dest, name, toVariable) \
+	if (zend_hash_find(HASH_P(dest), name, strlen(name)+1, (void**)&toVariable) == FAILURE) { \
+		zend_throw_exception(mongo_ce_GridFSException, "couldn't find " name, 0 TSRMLS_CC); \
+		return FAILURE; \
+	} \
+
+#define READ_OBJ_PROP(type, obj, name)  \
+	zend_read_property(mongo_ce_##type, obj, name, strlen(name), NOISY TSRMLS_CC);
+
+#define TO_INT(size, len) { \
+  if (Z_TYPE_PP(size) == IS_DOUBLE) { \
+	len = (int)Z_DVAL_PP(size); \
+  } else {  \
+	len = Z_LVAL_PP(size); \
+  } \
+}
+
+#define ASSERT_SIZE(size) \
+	if (size > self->chunkSize) { \
+		char * err; \
+		spprintf(&err, 0, "chunk %d has wrong size (%d) when the max is %d", chunk_id, size, self->chunkSize); \
+		zend_throw_exception(mongo_ce_GridFSException, err, 1 TSRMLS_CC); \
+		zval_ptr_dtor(&chunk); \
+		return FAILURE; \
+	} \
+/* }}} */
+
+/* {{{ php_stream * gridfs_stream_init(zval * file_object)  */
+php_stream * gridfs_stream_init(zval * file_object)
+{
+	gridfs_stream_data * self;
+	php_stream * stream;
+	zval * file, **id, **size, **chunkSize, *gridfs;
+
+	file = READ_OBJ_PROP(GridFSFile, file_object, "file");
+	READ_ARRAY_PROP(file, "_id", id);
+	READ_ARRAY_PROP(file, "length", size);
+	READ_ARRAY_PROP(file, "chunkSize", chunkSize);
+
+	gridfs = READ_OBJ_PROP(GridFSFile, file_object, "gridfs");
+
+	/* allocate memory and init the stream resource */
+	self = emalloc(sizeof(*self));
+	memset(self, 0, sizeof(*self));
+	TO_INT(size, self->size);
+	TO_INT(chunkSize, self->chunkSize);
+
+	self->fileObj  = file_object;
+
+	self->chunkObj = READ_OBJ_PROP(GridFS, gridfs, "chunks");
+	self->buffer   = emalloc(self->chunkSize +1);
+	self->id = *id;
+	self->chunkId = -1;
+	self->totalChunks = ceil(self->size/self->chunkSize);
+
+	zval_add_ref(&self->fileObj);
+	zval_add_ref(&self->chunkObj);
+	zval_add_ref(&self->id);
+
+
+	/* create base query object */
+	MAKE_STD_ZVAL(self->query);
+	array_init(self->query);
+	add_assoc_zval(self->query, "files_id", self->id);
+	zval_add_ref(&self->id);
+
+	stream = php_stream_alloc(&gridfs_stream_ops, self, 0, "rb");
+	return stream;
+}
+/* }}} */
+
+/* {{{ array fstat($fp) */
+static int gridfs_stat(php_stream *stream, php_stream_statbuf *ssb TSRMLS_DC)
+{
+	gridfs_stream_data * self = (gridfs_stream_data *) stream->abstract;
+
+	ssb->sb.st_size = self->size;
+
+	return SUCCESS;
+}
+/* }}} */
+
+/* {{{ int gridfs_read_chunk(gridfs_stream_data *self, int chunk_id) */
+static int gridfs_read_chunk(gridfs_stream_data *self, int chunk_id TSRMLS_DC)
+{
+	zval * chunk = 0, *zfields, **data, *bin;
+
+	if (chunk_id == -1) {
+		/* we need to figure out which chunk to load */
+		chunk_id = (int)(self->offset / self->chunkSize);
+	}
+
+	if (chunk_id == self->chunkId) {
+		/* nothing to load :-) */
+		return;
+	}
+
+	DEBUG(("loading chunk %d\n", chunk_id));
+
+	add_assoc_long(self->query, "n", chunk_id);
+
+	MAKE_STD_ZVAL(chunk);
+	MONGO_METHOD1(MongoCollection, findOne, chunk, self->chunkObj, self->query);
+
+	if (Z_TYPE_P(chunk) == IS_NULL) {
+		char * err;
+		spprintf(&err, 0, "couldn't find file chunk %d", chunk_id);
+		zend_throw_exception(mongo_ce_GridFSException, err, 1 TSRMLS_CC);
+		zval_ptr_dtor(&chunk);
+		return FAILURE;
+	}
+
+	READ_ARRAY_PROP(chunk, "data", data);
+
+	if (Z_TYPE_PP(data) == IS_STRING) {
+		ASSERT_SIZE(Z_STRLEN_PP(data))
+		memcpy(self->buffer, Z_STRVAL_PP(data), Z_STRLEN_PP(data));
+		self->buffer_size = Z_STRLEN_PP(data);
+	} else if (Z_TYPE_PP(data) == IS_OBJECT &&
+			 Z_OBJCE_PP(data) == mongo_ce_BinData) {
+
+		bin = READ_OBJ_PROP(BinData, *data, "bin");
+
+		ASSERT_SIZE(Z_STRLEN_P(bin))
+		memcpy(self->buffer, Z_STRVAL_P(bin), Z_STRLEN_P(bin));
+		self->buffer_size = Z_STRLEN_P(bin);
+	} else {
+		zend_throw_exception(mongo_ce_GridFSException, "chunk has wrong format", 0 TSRMLS_CC);
+		zval_ptr_dtor(&chunk);
+
+		return FAILURE;
+	}
+
+	self->chunkId = chunk_id;
+	self->buffer_offset  = self->offset%self->chunkSize;
+
+	zval_ptr_dtor(&chunk);
+	return SUCCESS;
+}
+/* }}} */
+
+/* {{{ fread($fp, $bytes) */
+static size_t gridfs_read(php_stream *stream, char *buf, size_t count TSRMLS_DC)
+{
+	gridfs_stream_data * self = (gridfs_stream_data *) stream->abstract;
+	int size, chunk_id;
+
+	/* load the needed chunk from mongo */
+	chunk_id = (int)((self->offset)/self->chunkSize);
+	if (gridfs_read_chunk(self, chunk_id TSRMLS_CC) == FAILURE) {
+		return -1;
+	}
+
+	size = MIN(count, self->buffer_size - self->buffer_offset);
+	memcpy(buf, self->buffer  + self->buffer_offset, size);
+
+	if (size < count && chunk_id < self->totalChunks) {
+		// load next chunk to return the exact requested bytes
+		if (gridfs_read_chunk(self, chunk_id+1 TSRMLS_CC) == FAILURE) {
+			return -1;
+		}
+		int tmp_bytes = MIN(count-size, self->buffer_size);
+		memcpy(buf+size, self->buffer, tmp_bytes);
+		size += tmp_bytes;
+	}
+
+	self->buffer_offset += size;
+	self->offset += size;
+
+
+	DEBUG(("offset=%d (+%d)\n", self->offset, size));
+
+	return size;
+}
+/* }}} */
+
+/* {{{ fseek($fp, $bytes, $whence) */
+static int gridfs_seek(php_stream *stream, off_t offset, int whence, off_t *newoffs TSRMLS_DC)
+{
+	gridfs_stream_data * self = (gridfs_stream_data *) stream->abstract;
+	int newoffset = 0;
+
+	switch (whence) {
+	case SEEK_SET:
+		newoffset = offset;
+		break;
+	case SEEK_CUR:
+		newoffset = self->offset + offset;
+		break;
+	case SEEK_END:
+		newoffset = self->size + offset;
+		break;
+	default:
+		return FAILURE;
+	}
+
+	if (newoffset > self->size) {
+		return FAILURE;
+	}
+
+	*newoffs = newoffset;
+	self->offset = newoffset;
+
+	if (self->chunkId != -1) {
+		/* change the offset also in the chunk */
+		self->buffer_offset = newoffset % self->chunkSize;
+	}
+
+	return SUCCESS;
+}
+/* }}} */
+
+/* {{{ fclose($fp) */
+static int gridfs_close(php_stream *stream, int close_handle TSRMLS_DC)
+{
+	gridfs_stream_data * self = (gridfs_stream_data *) stream->abstract;
+
+	zval_ptr_dtor(&self->fileObj);
+	zval_ptr_dtor(&self->chunkObj);
+	zval_ptr_dtor(&self->query);
+	zval_ptr_dtor(&self->id);
+
+	efree(self->buffer);
+	efree(self);
+
+	return 0;
+}
+/* }}} */
+
+/* {{{ feof */
+static int gridfs_option(php_stream *stream, int option, int value, void *ptrparam TSRMLS_DC)
+{
+
+	gridfs_stream_data * self = (gridfs_stream_data *) stream->abstract;
+	int ret = -1;
+
+	switch (option) {
+	case PHP_STREAM_OPTION_CHECK_LIVENESS:
+		ret = self->size == self->offset ? PHP_STREAM_OPTION_RETURN_ERR : PHP_STREAM_OPTION_RETURN_OK;
+	break;
+	}
+
+	return ret;
+}
+/* }}} */
+
+/*
+ * Local variables:
+ * tab-width: 4
+ * c-basic-offset: 4
+ * End:
+ * vim600: noet sw=4 ts=4 fdm=marker
+ * vim<600: noet sw=4 ts=4
+ */

--- a/tests/gridfs-fseek.phpt
+++ b/tests/gridfs-fseek.phpt
@@ -1,0 +1,60 @@
+--TEST--
+Testing fseek and fread
+--FILE--
+<?php
+$conn = new Mongo();
+$db   = $conn->selectDb('admin');
+$grid = $db->getGridFs('wrapper');
+
+// delete any previous results
+$grid->drop();
+
+// dummy file
+$bytes = "";
+for ($i=0; $i < 200*1024; $i++) {
+    $bytes .= sha1(rand(1, 1000000000));
+}
+$length = 200*1024 * 40;
+
+$grid->storeBytes($bytes, array("filename" => "demo.txt"));
+
+// fetch it
+$file = $grid->findOne(array('filename' => 'demo.txt'));
+$chunkSize = $file->file['chunkSize'];
+
+// get file descriptor
+$fp = $file->getResource();
+
+/* seek test */
+$result = true;
+$iter   = 5000;
+for ($i=0; $i < $iter && $result; $i++) {
+    $offset = rand(0, $chunkSize/2);
+    $base   = rand(0, $chunkSize/2);
+
+    fseek($fp, $base, SEEK_SET);
+    $result &= ((string)substr($bytes, $base, 1024)) === ($read=fread($fp, 1024));
+    if (!$result) {
+        var_dump($offset, $base, $read);
+        die("FAILED: SEEK_SET");
+    }
+
+    fseek($fp, $offset, SEEK_CUR);
+    $result &= ((string)substr($bytes, $base + 1024 + $offset, 1024)) === ($read=fread($fp, 1024));
+    if (!$result) {
+        var_dump($offset, $base, $read);
+        die("FAILED: SEEK_CUR");
+    }
+    
+    fseek($fp, -1*$base, SEEK_END);
+    $result &= ((string)substr($bytes, $length - $base, 1024)) === ($read=fread($fp, 1024));
+    if (!$result) {
+        var_dump($offset, $base, $read);
+        die("FAILED: SEEK_END");
+    }
+}
+
+var_dump($result && $i === $iter);
+
+--EXPECTF--
+bool(true)

--- a/tests/gridfs-memory-usage.phpt
+++ b/tests/gridfs-memory-usage.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Testing memory usage
+--FILE--
+<?php
+$conn = new Mongo();
+$db   = $conn->selectDb('admin');
+$grid = $db->getGridFs('wrapper');
+
+// delete any previous results
+$grid->drop();
+
+// dummy file
+$bytes = "";
+for ($i=0; $i < 200*1024; $i++) {
+    $bytes .= sha1(rand(1, 1000000000));
+}
+$grid->storeBytes($bytes, array("filename" => "demo.txt"), array('safe' => true));
+
+// fetch it
+$file = $grid->findOne(array('filename' => 'demo.txt'));
+$chunkSize = $file->file['chunkSize'];
+
+// get file descriptor
+$fp = $file->getResource();
+
+$memory = memory_get_usage();
+
+$tmp = "";
+$i=0;
+while (!feof($fp)) {
+    $tmp .= ($t=fread($fp, rand(1024,8024)));
+}
+var_dump($bytes === $tmp);
+
+// memory leak checks
+var_dump((memory_get_usage() - $memory - strlen($tmp)) < $chunkSize * 1.5 );
+fclose($fp);
+
+var_dump((memory_get_usage() - $memory - strlen($tmp)) < $chunkSize *.5);
+--EXPECTF--
+bool(true)
+bool(true)
+bool(true)

--- a/tests/gridfs-streaming.phpt
+++ b/tests/gridfs-streaming.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Testing reading the whole file
+--FILE--
+<?php
+$conn = new Mongo();
+$db   = $conn->selectDb('admin');
+$grid = $db->getGridFs('wrapper');
+
+// delete any previous results
+$grid->drop();
+
+// dummy file
+$bytes = "";
+for ($i=0; $i < 200*1024; $i++) {
+    $bytes .= sha1(rand(1, 1000000000));
+}
+$grid->storeBytes($bytes, array("filename" => "demo.txt"));
+
+// fetch it
+$file = $grid->findOne(array('filename' => 'demo.txt'));
+
+// get file descriptor
+$fp = $file->getResource();
+
+$tmp = "";
+$i=0;
+while (!feof($fp)) {
+    $tmp .= ($t=fread($fp, rand(1024,8024)));
+}
+var_dump($bytes === $tmp);
+--EXPECTF--
+bool(true)

--- a/tests/gridfs-wrapper.phpt
+++ b/tests/gridfs-wrapper.phpt
@@ -1,0 +1,88 @@
+--TEST--
+Test for basic stream wrapper support
+--FILE--
+<?php
+$conn = new Mongo();
+$db   = $conn->selectDb('admin');
+$grid = $db->getGridFs('wrapper');
+
+// delete any previous results
+$grid->drop();
+
+// dummy file
+$bytes = "";
+for ($i=0; $i < 200*1024; $i++) {
+    $bytes .= sha1(rand(1, 1000000000));
+}
+$grid->storeBytes($bytes, array("filename" => "demo.txt"));
+
+// fetch it
+$file = $grid->findOne(array('filename' => 'demo.txt'));
+
+// get file descriptor
+$fp = $file->getResource();
+/**/
+var_dump($fp);
+var_dump(fstat($fp));
+var_dump(substr($bytes,0,1024) === fread($fp, 1024));
+var_dump(feof($fp) === false);
+
+
+--EXPECTF--
+resource(%d) of type (stream)
+array(26) {
+  [0]=>
+  int(0)
+  [1]=>
+  int(0)
+  [2]=>
+  int(0)
+  [3]=>
+  int(0)
+  [4]=>
+  int(0)
+  [5]=>
+  int(0)
+  [6]=>
+  int(0)
+  [7]=>
+  int(%d)
+  [8]=>
+  int(0)
+  [9]=>
+  int(0)
+  [10]=>
+  int(0)
+  [11]=>
+  int(0)
+  [12]=>
+  int(0)
+  ["dev"]=>
+  int(0)
+  ["ino"]=>
+  int(0)
+  ["mode"]=>
+  int(0)
+  ["nlink"]=>
+  int(0)
+  ["uid"]=>
+  int(0)
+  ["gid"]=>
+  int(0)
+  ["rdev"]=>
+  int(0)
+  ["size"]=>
+  int(%d)
+  ["atime"]=>
+  int(0)
+  ["mtime"]=>
+  int(0)
+  ["ctime"]=>
+  int(0)
+  ["blksize"]=>
+  int(0)
+  ["blocks"]=>
+  int(0)
+}
+bool(true)
+bool(true)


### PR DESCRIPTION
I added add new method (`getResource()`) to `MongoGridFSFile` that basically returns a _file-descriptor_ (per say in reality it's a stream resource) so the file function (such as fread, fseek, fclose) can be used with files stored on Mongo.
## How to use it

```
$conn = new Mongo
$db   = $conn->someDatabase;
$grid = $db->getGridFs();

$file = $grid->findOne(array('name' => 'foobar.txt'));
$fp   = $file->getResource();

fseek($fp, -1024, SEEK_SET);
echo fread($fp, 1024);
fclose($fp);
```
## Some details
1. The code (`gridfs_stream.c`) looks very similar to `gridfs.c`, perhaps I could refactor both later to reuse more code.
2. It is holding in memory only _one_ chunk at a time, it could hold multiple chunks with some changes (i.e, to support read ahead), but I strongly belive that memory is more important than a bit of performance in this particular case.
3. `getResource()` is only returning the resource, no database operation is performed (chunk loading) until fread is called (also fseek just changes the offset position).
4. I wrote tests for what I considered important, fread, fseek+fread and memory consumption  (if something is missing let me know).
5. I think would great to make it less verbosed perhaps `findOneFs($query)` method that will an alias for `findOne($query)->getResource()`
6. All tests will fail until https://github.com/mongodb/mongo-php-driver/pull/12 is applied.
