### PR TITLE
V1.2 fix:PHP-325 (mongo-php-driver abort with SEGV)

### DIFF
--- a/db.c
+++ b/db.c
@@ -607,6 +607,9 @@ zval* mongo_db_cmd(mongo_server *current, zval *cmd TSRMLS_DC) {
   temp.server_set->master = current;
   temp.rs = 0;
 
+  temp.slave = 0;
+  temp.db    = 0;
+
   temp_next = current->next;
   current->next = 0;
 

--- a/util/pool.c
+++ b/util/pool.c
@@ -164,18 +164,24 @@ void mongo_util_pool_close(mongo_server *server, int check_conns TSRMLS_DC) {
 }
 
 static void test_other_conns(mongo_server *server, stack_monitor *monitor TSRMLS_DC) {
-  mongo_server other;
+  mongo_server *other;
   zval *response = 0;
 
+  // initialize temp
+  other = mongo_util_server_copy(server, 0, NO_PERSIST TSRMLS_CC);
+
   // get another connection
-  get_other_conn(server, &other, monitor);
+  get_other_conn(server, other, monitor);
+
+  // destroy temp
+  php_mongo_server_free(other, NO_PERSIST TSRMLS_CC);
 
   // if no other connections open, we don't have to worry about closing them
-  if (other.connected == 0) {
+  if (other->connected == 0) {
     return;
   }
 
-  response = mongo_util_rs__cmd("ping", &other TSRMLS_CC);
+  response = mongo_util_rs__cmd("ping", other TSRMLS_CC);
 
   if (!response) {
     mongo_util_pool__close_connections(monitor TSRMLS_CC);


### PR DESCRIPTION
This issue is occurred at test_other_conns() in 'pool.c'.
The 'other' variable is not initialized.
And it looks like initialized at the get_other_conns() function called by test_other_conns.
But actually it just update only 'other.sock'.

However, other member variables inside 'other' such as 'host' is never initialized but were referenced.

So I think it should be solved using mongo_util_server_copy() to initialize 'other' !!
