### PR TITLE
Fix compilation of gridfs_read_chunk

### DIFF
--- a/gridfs_stream.c
+++ b/gridfs_stream.c
@@ -211,7 +211,7 @@ static int gridfs_read_chunk(gridfs_stream_data *self, int chunk_id TSRMLS_DC)
 
 	if (chunk_id == self->chunkId) {
 		/* nothing to load :-) */
-		return;
+		return SUCCESS;
 	}
 
 	DEBUG(("loading chunk %d\n", chunk_id));


### PR DESCRIPTION
Return success when chunk already is loaded, also fixes compile warning/error message
