### PR TITLE
Fix "iterator_to_array(MongoCursor, true)" return one element if "find(array(), array('_id' => 0))"

### DIFF
--- a/cursor.c
+++ b/cursor.c
@@ -751,7 +751,7 @@ PHP_METHOD(MongoCursor, key) {
     }
   }
   else {
-    RETURN_STRING("", 1);
+    RETURN_LONG(cursor->at);
   }
 }
 /* }}} */


### PR DESCRIPTION
Fix `iterator_to_array(MongoCursor, true)` return one element if `find(array(), array('_id' => 0))`

Another words: if result doesn`t have "_id" field

With `iterator_to_array(MongoCursor, false)` all ok, but I don`t think that programmers expecting such behaviour

Code to reproduce:

<pre>
<?
$m = new Mongo();

$coll = $m->test->not_existed_collection;
$coll->insert(array('foo' => 1));
$coll->insert(array('foo' => 2));

assert(count(iterator_to_array($coll->find(array(), array('_id' => 0)))) == iterator_count($coll->find(array(), array('_id' => 0))));

$coll->drop();
</pre>
