### PR TITLE
Fix for PHP-329: Added two ini settings to control ping and is_master intervals.

### DIFF
--- a/php_mongo.c
+++ b/php_mongo.c
@@ -124,6 +124,8 @@ STD_PHP_INI_ENTRY("mongo.native_long", "0", PHP_INI_ALL, OnUpdateLong, native_lo
 STD_PHP_INI_ENTRY("mongo.long_as_object", "0", PHP_INI_ALL, OnUpdateLong, long_as_object, zend_mongo_globals, mongo_globals)
 STD_PHP_INI_ENTRY("mongo.allow_empty_keys", "0", PHP_INI_ALL, OnUpdateLong, allow_empty_keys, zend_mongo_globals, mongo_globals)
 STD_PHP_INI_ENTRY("mongo.no_id", "0", PHP_INI_SYSTEM, OnUpdateLong, no_id, zend_mongo_globals, mongo_globals)
+STD_PHP_INI_ENTRY("mongo.ping_interval", "5", PHP_INI_ALL, OnUpdateLong, ping_interval, zend_mongo_globals, mongo_globals)
+STD_PHP_INI_ENTRY("mongo.is_master_interval", "60", PHP_INI_ALL, OnUpdateLong, is_master_interval, zend_mongo_globals, mongo_globals)
 PHP_INI_END()
 /* }}} */
 

--- a/php_mongo.h
+++ b/php_mongo.h
@@ -595,6 +595,9 @@ int pool_size;
 
 	long log_level;
 	long log_module;
+
+	long ping_interval;
+	long is_master_interval;
 ZEND_END_MODULE_GLOBALS(mongo)
 
 #ifdef ZTS

--- a/util/server.c
+++ b/util/server.c
@@ -29,6 +29,7 @@
 
 extern int le_pserver;
 extern zend_class_entry *mongo_ce_Id;
+ZEND_EXTERN_MODULE_GLOBALS(mongo);
 
 static server_info* create_info();
 static void make_other_le(const char *id, server_info *info TSRMLS_DC);

--- a/util/server.h
+++ b/util/server.h
@@ -69,8 +69,8 @@ typedef struct _server_info {
 #define MONGO_SERVER_PING INT_MAX
 #define MONGO_SERVER_BSON (4*1024*1024)
 
-#define MONGO_PING_INTERVAL 5
-#define MONGO_ISMASTER_INTERVAL 60
+#define MONGO_PING_INTERVAL (MonGlo(ping_interval))
+#define MONGO_ISMASTER_INTERVAL (MonGlo(is_master_interval))
 
 // ------- Server Info Interface -----------
 


### PR DESCRIPTION
I've done some research and the current behaviour, although unexpected, is not quite a bug. We have a 5 and 60 second timeout for running ping/is_master to prevent the secondaries not from being slammed with pings/is_master calls when a primary goes down. I've created a patch that introduces two settings:

mongo.ping_interval

and

mongo.is_master_interval

If you set both of those to 1 then the driver sees within a second that something was wrong.
