### PR TITLE
Fixed PHP-368: uploadDate is missing in the file property of the MongoGridFSFile class.

### DIFF
--- a/gridfs.c
+++ b/gridfs.c
@@ -423,6 +423,8 @@ PHP_METHOD(MongoGridFS, storeBytes) {
 
   // merge extra & zfile and add _id if needed
   zid = setup_extra(zfile, extra TSRMLS_CC);
+  setup_file_fields(zfile, NULL, bytes_len TSRMLS_CC);
+
   // chunkSize
   global_chunk_size = get_chunk_size(zfile TSRMLS_CC);
 
@@ -492,31 +494,31 @@ cleanup_on_failure:
  * - length
  * these fields are only added if the user hasn't defined them.
  */
-static int setup_file_fields(zval *zfile, char *filename, int size TSRMLS_DC) {
-  zval temp;
+static int setup_file_fields(zval *zfile, char *filename, int length TSRMLS_DC)
+{
+	zval temp;
 
-  // filename
-  if (filename && !zend_hash_exists(HASH_P(zfile), "filename", strlen("filename")+1)) {
-    add_assoc_stringl(zfile, "filename", filename, strlen(filename), DUP);
-  }
+	// filename
+	if (filename && !zend_hash_exists(HASH_P(zfile), "filename", strlen("filename")+1)) {
+		add_assoc_stringl(zfile, "filename", filename, strlen(filename), DUP);
+	}
 
-  // uploadDate
-  if (!zend_hash_exists(HASH_P(zfile), "uploadDate", strlen("uploadDate")+1)) {
-    // create an id for the file
-    zval *upload_date;
-    MAKE_STD_ZVAL(upload_date);
-    object_init_ex(upload_date, mongo_ce_Date);
-    MONGO_METHOD(MongoDate, __construct, &temp, upload_date);
+	// uploadDate
+	if (!zend_hash_exists(HASH_P(zfile), "uploadDate", strlen("uploadDate")+1)) {
+		zval *upload_date;
+		MAKE_STD_ZVAL(upload_date);
+		object_init_ex(upload_date, mongo_ce_Date);
+		MONGO_METHOD(MongoDate, __construct, &temp, upload_date);
 
-    add_assoc_zval(zfile, "uploadDate", upload_date);
-  }
+		add_assoc_zval(zfile, "uploadDate", upload_date);
+	}
 
-  // size
-  if (!zend_hash_exists(HASH_P(zfile), "length", strlen("length")+1)) {
-    add_assoc_long(zfile, "length", size);
-  }
+	// length
+	if (!zend_hash_exists(HASH_P(zfile), "length", strlen("length")+1)) {
+		add_assoc_long(zfile, "length", length);
+	}
 
-  return SUCCESS;
+	return SUCCESS;
 }
 
 /* Creates a chunk and adds it to the chunks collection as:

--- a/tests/bug00343-1.phpt
+++ b/tests/bug00343-1.phpt
@@ -7,11 +7,12 @@ $m = new Mongo(); // i.e. a remote host
 $db = $m->phpunit;
 $db->dropCollection( 'phpunit' );
 $grid = $db->getGridFS();
+$grid->drop();
 $saved = $grid->storeBytes(
 	$bytes,
 	array(
 		'filename' => 'test_file-'.rand(0,10000),
-		'size' => 'm',
+		'thumbnail_size' => 'm',
 		'otherdata' => 'BIG'
 	),
 	array('safe' => true)
@@ -20,22 +21,29 @@ var_dump( $grid->findOne() );
 echo "OK\n";
 ?>
 --EXPECTF--
-object(MongoGridFSFile)#7 (2) {
+object(MongoGridFSFile)#%d (2) {
   ["file"]=>
-  array(6) {
+  array(8) {
     ["_id"]=>
-    string(5) "file0"
+    object(MongoId)#%d (1) {
+      ["$id"]=>
+      string(24) "%s"
+    }
     ["filename"]=>
-    string(9) "file0.txt"
+    string(%d) "test_file-%d"
+    ["thumbnail_size"]=>
+    string(1) "m"
+    ["otherdata"]=>
+    string(3) "BIG"
     ["uploadDate"]=>
-    object(MongoDate)#8 (2) {
+    object(MongoDate)#9 (2) {
       ["sec"]=>
-      int(%d)
+      int(1%d)
       ["usec"]=>
       int(%d)
     }
     ["length"]=>
-    int(10)
+    int(1%d)
     ["chunkSize"]=>
     int(262144)
     ["md5"]=>

--- a/tests/bug00343-2.phpt
+++ b/tests/bug00343-2.phpt
@@ -6,11 +6,12 @@ $m = new Mongo(); // i.e. a remote host
 $db = $m->phpunit;
 $db->dropCollection( 'phpunit' );
 $grid = $db->getGridFS();
+$grid->drop();
 $saved = $grid->storeFile(
 	'tests/bug00343-2.phpt',
 	array(
 		'filename' => 'test_file-'.rand(0,10000),
-		'size' => 'm',
+		'thumbnail_size' => 'm',
 		'otherdata' => 'BIG'
 	),
 	array('safe' => true)
@@ -19,22 +20,29 @@ var_dump( $grid->findOne() );
 echo "OK\n";
 ?>
 --EXPECTF--
-object(MongoGridFSFile)#6 (2) {
+object(MongoGridFSFile)#%d (2) {
   ["file"]=>
-  array(6) {
+  array(8) {
     ["_id"]=>
-    string(5) "file0"
+    object(MongoId)#6 (1) {
+      ["$id"]=>
+      string(24) "%s"
+    }
     ["filename"]=>
-    string(9) "file0.txt"
+    string(%d) "test_file-%d"
+    ["thumbnail_size"]=>
+    string(1) "m"
+    ["otherdata"]=>
+    string(3) "BIG"
     ["uploadDate"]=>
-    object(MongoDate)#7 (2) {
+    object(MongoDate)#9 (2) {
       ["sec"]=>
       int(%d)
       ["usec"]=>
       int(%d)
     }
     ["length"]=>
-    int(10)
+    int(1%d)
     ["chunkSize"]=>
     int(262144)
     ["md5"]=>


### PR DESCRIPTION
This was only a problem for ->storeBytes() as ->storeFile() already had it done correctly.
This also fixes the existing tests for this.
