### PR TITLE
PHP-392

### DIFF
--- a/util/connect.c
+++ b/util/connect.c
@@ -292,9 +292,9 @@ int mongo_util_connect_authenticate(mongo_server *server, zval *errmsg TSRMLS_DC
 
   // check if we've logged in successfully
   if (!logged_in) {
-    char *full_error;
-    spprintf(&full_error, 0, "Couldn't authenticate with database %s: username [%s], password [%s]", server->db, server->username, server->password);
     if (errmsg) {
+      char *full_error;
+      spprintf(&full_error, 0, "Couldn't authenticate with database %s: username [%s], password [%s]", server->db, server->username, server->password);
       ZVAL_STRING(errmsg, full_error, 0);
     }
     zval_ptr_dtor(&ok);


### PR DESCRIPTION
Skip authentication to arbiters & fix memory leak when providing incorrect credentials (i.e. authenticating with a database specific user without providing the database name).
