### PR TITLE
[PHP-397] Use localhost connection in phpt

### DIFF
--- a/tests/bug00397.phpt
+++ b/tests/bug00397.phpt
@@ -2,7 +2,7 @@
 Bug PHP-397 Endless loop on non-existing file
 --FILE--
 <?php
-$m = new Mongo("mongodb://user:user@primary.local:27001/phpunit-auth", array("replicaSet" => "foobar"));
+$m = new Mongo();
 $db = $m->selectDB("phpunit-unit");
 $c = $db->selectCollection("example");
 $c->setSlaveOkay(true);


### PR DESCRIPTION
There was no other reference to the phpunit-auth database in the test suite, nor the primary.local hostname.
