### PR TITLE
Add zend_parse_parameters_none for older builds

### DIFF
--- a/db.c
+++ b/db.c
@@ -29,6 +29,10 @@
 #include "gridfs.h"
 #include "mongo_types.h"
 
+#ifndef zend_parse_parameters_none
+#define zend_parse_parameters_none()    \
+        zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "")
+#endif
 
 extern zend_class_entry *mongo_ce_Mongo,
   *mongo_ce_Collection,


### PR DESCRIPTION
I realize that zend_parse_parameters_none() went into the Zend api in 2008, but I'm still stuck with php 5.2. I got this fix from the mysqli code.
