### PR TITLE
Relax var_dump() expectations in GridFS segfault tests

### DIFF
--- a/tests/generic/bug00343-1.phpt
+++ b/tests/generic/bug00343-1.phpt
@@ -24,7 +24,7 @@ var_dump( $grid->findOne() );
 echo "OK\n";
 ?>
 --EXPECTF--
-object(MongoGridFSFile)#%d (%d) {
+object(MongoGridFSFile)#%d (3) {
   ["file"]=>
   array(8) {
     ["_id"]=>
@@ -53,13 +53,13 @@ object(MongoGridFSFile)#%d (%d) {
     string(32) "%s"
   }
   ["gridfs%S:protected%S]=>
-  object(MongoGridFS)#3 (5) {
+  object(MongoGridFS)#%d (5) {
     ["w"]=>
     int(1)
     ["wtimeout"]=>
     int(10000)
     ["chunks"]=>
-    object(MongoCollection)#4 (2) {
+    object(MongoCollection)#%d (2) {
       ["w"]=>
       int(1)
       ["wtimeout"]=>

--- a/tests/generic/bug00343-2.phpt
+++ b/tests/generic/bug00343-2.phpt
@@ -23,7 +23,7 @@ var_dump( $grid->findOne() );
 echo "OK\n";
 ?>
 --EXPECTF--
-object(MongoGridFSFile)#%d (%d) {
+object(MongoGridFSFile)#%d (3) {
   ["file"]=>
   array(8) {
     ["_id"]=>
@@ -52,13 +52,13 @@ object(MongoGridFSFile)#%d (%d) {
     string(32) "%s"
   }
   ["gridfs%S:protected%S]=>
-  object(MongoGridFS)#3 (5) {
+  object(MongoGridFS)#%d (5) {
     ["w"]=>
     int(1)
     ["wtimeout"]=>
     int(10000)
     ["chunks"]=>
-    object(MongoCollection)#4 (2) {
+    object(MongoCollection)#%d (2) {
       ["w"]=>
       int(1)
       ["wtimeout"]=>


### PR DESCRIPTION
Prevents failures when running the test suite with standalone auth, as the object number would be off by one.
