### PR TITLE
[PHP-414] Create MongoLog::PARSE constant, increase ALL value

### DIFF
--- a/tests/others/mongolog-001.phpt
+++ b/tests/others/mongolog-001.phpt
@@ -1,0 +1,33 @@
+--TEST--
+MongoLog constants
+--SKIPIF--
+<?php require dirname(__FILE__) ."/skipif.inc"; ?>
+--FILE--
+<?php
+// Common constants
+var_dump(0 === MongoLog::NONE);
+var_dump(31 === MongoLog::ALL);
+
+// MongoLog::setLevel() constants
+var_dump(1 === MongoLog::WARNING);
+var_dump(2 === MongoLog::INFO);
+var_dump(4 === MongoLog::FINE);
+
+// MongoLog::setModule() constants
+var_dump(1 === MongoLog::RS);
+var_dump(2 === MongoLog::POOL);
+var_dump(4 === MongoLog::IO);
+var_dump(8 === MongoLog::SERVER);
+var_dump(16 === MongoLog::PARSE);
+?>
+--EXPECTF--
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+bool(true)

--- a/tests/standalone/mongolog-001.phpt
+++ b/tests/standalone/mongolog-001.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test for MongoLog (IO only)
+MongoLog (all levels, all modules)
 --SKIPIF--
 <?php require dirname(__FILE__) ."/skipif.inc"; ?>
 --FILE--
@@ -12,7 +12,7 @@ function error_handler($code, $message)
 
 set_error_handler('error_handler');
 
-MongoLog::setModule(MongoLog::IO);
+MongoLog::setModule(MongoLog::ALL);
 MongoLog::setLevel(MongoLog::ALL);
 $m = new Mongo("mongodb://$STANDALONE_HOSTNAME:$STANDALONE_PORT");
 ?>
@@ -20,3 +20,6 @@ $m = new Mongo("mongodb://$STANDALONE_HOSTNAME:$STANDALONE_PORT");
 Mongo::__construct(): parsing servers
 Mongo::__construct(): current: %s
 Mongo::__construct(): done parsing
+Mongo::__construct(): %s:%d: pool get (%s)
+Mongo::__construct(): %s:%d: pool connect (%s)
+Unknown: %s:%d: pool done (%s)

--- a/tests/standalone/mongolog-002.phpt
+++ b/tests/standalone/mongolog-002.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test for MongoLog
+MongoLog (all levels, pool module)
 --SKIPIF--
 <?php require dirname(__FILE__) ."/skipif.inc"; ?>
 --FILE--
@@ -12,14 +12,11 @@ function error_handler($code, $message)
 
 set_error_handler('error_handler');
 
-MongoLog::setModule(MongoLog::ALL);
+MongoLog::setModule(MongoLog::POOL);
 MongoLog::setLevel(MongoLog::ALL);
 $m = new Mongo("mongodb://$STANDALONE_HOSTNAME:$STANDALONE_PORT");
 ?>
 --EXPECTF--
-Mongo::__construct(): parsing servers
-Mongo::__construct(): current: %s
-Mongo::__construct(): done parsing
 Mongo::__construct(): %s:%d: pool get (%s)
 Mongo::__construct(): %s:%d: pool connect (%s)
 Unknown: %s:%d: pool done (%s)

--- a/tests/standalone/mongolog-003.phpt
+++ b/tests/standalone/mongolog-003.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test for MongoLog (pool only)
+MongoLog (all levels, parse module)
 --SKIPIF--
 <?php require dirname(__FILE__) ."/skipif.inc"; ?>
 --FILE--
@@ -12,11 +12,11 @@ function error_handler($code, $message)
 
 set_error_handler('error_handler');
 
-MongoLog::setModule(MongoLog::POOL);
+MongoLog::setModule(MongoLog::PARSE);
 MongoLog::setLevel(MongoLog::ALL);
 $m = new Mongo("mongodb://$STANDALONE_HOSTNAME:$STANDALONE_PORT");
 ?>
 --EXPECTF--
-Mongo::__construct(): %s:%d: pool get (%s)
-Mongo::__construct(): %s:%d: pool connect (%s)
-Unknown: %s:%d: pool done (%s)
+Mongo::__construct(): parsing servers
+Mongo::__construct(): current: %s
+Mongo::__construct(): done parsing

--- a/tests/standalone/mongolog-004.phpt
+++ b/tests/standalone/mongolog-004.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test for MongoLog (level variations)
+MongoLog (various levels, all modules)
 --SKIPIF--
 <?php require dirname(__FILE__) ."/skipif.inc"; ?>
 --FILE--

--- a/util/log.c
+++ b/util/log.c
@@ -50,6 +50,7 @@ void mongo_init_MongoLog(TSRMLS_D) {
   zend_declare_class_constant_long(mongo_ce_Log, "POOL", strlen("POOL"), MONGO_LOG_POOL TSRMLS_CC);
   zend_declare_class_constant_long(mongo_ce_Log, "IO", strlen("IO"), MONGO_LOG_IO TSRMLS_CC);
   zend_declare_class_constant_long(mongo_ce_Log, "SERVER", strlen("SERVER"), MONGO_LOG_SERVER TSRMLS_CC);
+  zend_declare_class_constant_long(mongo_ce_Log, "PARSE", strlen("PARSE"), MONGO_LOG_PARSE TSRMLS_CC);
   zend_declare_class_constant_long(mongo_ce_Log, "ALL", strlen("ALL"), MONGO_LOG_ALL TSRMLS_CC);
 
   zend_declare_property_long(mongo_ce_Log, "level", strlen("level"), 0, ZEND_ACC_PRIVATE|ZEND_ACC_STATIC TSRMLS_CC);

--- a/util/log.h
+++ b/util/log.h
@@ -28,8 +28,8 @@
 #define MONGO_LOG_POOL 2
 #define MONGO_LOG_IO 4
 #define MONGO_LOG_SERVER 8
-#define MONGO_LOG_PARSE 4
-#define MONGO_LOG_ALL 15
+#define MONGO_LOG_PARSE 16
+#define MONGO_LOG_ALL 31
 
 void mongo_init_MongoLog(TSRMLS_D);
 


### PR DESCRIPTION
The IO and PARSE constants were using the same value, and PARSE was never exposed as a PHP constant. This redefines it to not conflict with IO, which also required bumping the value of ALL.

Added a test for the expected constant values and renamed the existing tests to be consistent.

Note: this might be a small BC break for anyone that was using `MongoLog::IO` to collect parse output.
