### PR TITLE
Crumbjp v1.2

### DIFF
--- a/mongo.c
+++ b/mongo.c
@@ -698,7 +698,7 @@ PHP_METHOD(Mongo, switchSlave) {
     return;
   }
 
-  mongo_util_rs_ping(link TSRMLS_CC);
+  mongo_util_rs_ping(link,MONGO_INTERVAL_FOECE_LV0 TSRMLS_CC);
   if (mongo_util_rs__set_slave(link, &errmsg TSRMLS_CC) == FAILURE) {
     if (!EG(exception)) {
       if (errmsg) {

--- a/util/link.c
+++ b/util/link.c
@@ -40,7 +40,7 @@ mongo_server* mongo_util_link_get_slave_socket(mongo_link *link, zval *errmsg TS
   }
 
   // see if we need to update hosts or ping them
-  mongo_util_rs_ping(link TSRMLS_CC);
+  mongo_util_rs_ping(link,MONGO_INTERVAL_FOECE_LV0 TSRMLS_CC);
 
   if (link->slave) {
     if (mongo_util_pool_refresh(link->slave, link->timeout TSRMLS_CC) == SUCCESS) {
@@ -72,7 +72,7 @@ mongo_server* mongo_util_link_get_socket(mongo_link *link, zval *errmsg TSRMLS_D
     potential_master = mongo_util_rs_get_master(link TSRMLS_CC);
 
     if (potential_master == 0) {
-      mongo_util_rs_ping(link TSRMLS_CC);
+      mongo_util_rs_ping(link,MONGO_INTERVAL_FOECE_LV1 TSRMLS_CC);
       ZVAL_STRING(errmsg, "couldn't determine master", 1);
     }
 
@@ -124,7 +124,7 @@ int mongo_util_link_failed(mongo_link *link, mongo_server *server TSRMLS_DC) {
       goto bailout;
     }
 
-    mongo_util_rs__ping(monitor TSRMLS_CC);
+    mongo_util_rs__ping(monitor,MONGO_INTERVAL_FOECE_LV2 TSRMLS_CC);
   }
 
 bailout:
@@ -148,7 +148,7 @@ void mongo_util_link_master_failed(mongo_link *link TSRMLS_DC) {
   link->server_set->master = 0;
   link->slave = 0;
 
-  mongo_util_rs_ping(link TSRMLS_CC);
+  mongo_util_rs_ping(link,MONGO_INTERVAL_FOECE_LV2 TSRMLS_CC);
 }
 
 void mongo_util_link_disconnect(mongo_link *link TSRMLS_DC) {

--- a/util/rs.h
+++ b/util/rs.h
@@ -86,14 +86,14 @@ mongo_server* mongo_util_rs_get_master(mongo_link *link TSRMLS_DC);
  */
 int mongo_util_rs__set_slave(mongo_link *link, char **errmsg TSRMLS_DC);
 
-void mongo_util_rs_ping(mongo_link *link TSRMLS_DC);
+void mongo_util_rs_ping(mongo_link *link, int force TSRMLS_DC);
 
 /**
  * Clears the hosts, returning each host to the pool. Takes the output of
  * rs__ismaster and looks through the hosts and passives fields to build a new
  * list of hosts.
  */
-void mongo_util_rs_refresh(rs_monitor *monitor, time_t now TSRMLS_DC);
+void mongo_util_rs_refresh(rs_monitor *monitor, time_t now, int force TSRMLS_DC);
 
 /**
  * Free ping time.
@@ -109,7 +109,7 @@ void mongo_util_rs_shutdown(zend_rsrc_list_entry *rsrc TSRMLS_DC);
  */
 rs_monitor* mongo_util_rs__get_monitor(mongo_link *link TSRMLS_DC);
 
-void mongo_util_rs__ping(rs_monitor *monitor TSRMLS_DC);
+void mongo_util_rs__ping(rs_monitor *monitor, int force TSRMLS_DC);
 
 /**
  * Calls ismaster on the given server.

--- a/util/server.h
+++ b/util/server.h
@@ -72,6 +72,9 @@ typedef struct _server_info {
 #define MONGO_PING_INTERVAL (MonGlo(ping_interval))
 #define MONGO_ISMASTER_INTERVAL (MonGlo(is_master_interval))
 
+#define MONGO_INTERVAL_FOECE_LV0 (0)  // Follow the intervals
+#define MONGO_INTERVAL_FOECE_LV1 (1)  // Ignore ISMASTER_INTERVAL but follow PING_INTERVAL
+#define MONGO_INTERVAL_FOECE_LV2 (2)  // Ignore intervals
 // ------- Server Info Interface -----------
 
 /**
@@ -100,7 +103,7 @@ int mongo_util_server_cmp(char *host1, char *host2 TSRMLS_DC);
  *
  * Returns SUCCESS if this server is readable, failure otherwise.
  */
-int mongo_util_server_ping(mongo_server *server, time_t now TSRMLS_DC);
+int mongo_util_server_ping(mongo_server *server, time_t now, int force TSRMLS_DC);
 
 /**
  * If it's been ISMASTER_INTERVAL since we last pinged this server, calls isMaster


### PR DESCRIPTION
I add the force ping flags to any ??ping functions to follow changing replica-set status more quickly.
It'll work as the following types of the list.

[ Normal time ] 
- No change in this patch

[ Master down ]
1. It'll can be detected by mongo_util_link_failed(link.c) at the first requst but not important.
2. It'll be detected by mongo_util_link_get_socket (link.c) at every request.
3. It call mongo_util_rs_ping() with MONGO_INTERVAL_FOECE_LV1 is added by this patch.
4. And, it call mongo_util_rs_refresh() and mongo_util_server_ismaster() as for every 5 seconds. 
   It depends on MONGO_PING_INTERVAL value.

[ Master change ]
1. It'll be detected by mongo_util_link_failed(link.c) at the first requst as the "not master" error.
2. It call mongo_util_rs_ping() with MONGO_INTERVAL_FOECE_LV2 is added by this patch.
3. And, it certainly call mongo_util_rs_refresh() and mongo_util_server_ismaster() to reflesh replica-set status.
4. Then, it'll get the status of no master.
5. It'll do same as the [ Master down ]
