### PR TITLE
Added checks so that connections are only attempted to be made once every ping_interval seconds.

### DIFF
--- a/mcon/parse.c
+++ b/mcon/parse.c
@@ -171,6 +171,7 @@ void static mongo_add_parsed_server_addr(mongo_con_manager *manager, mongo_serve
 	memset(tmp, 0, sizeof(mongo_server_def));
 	tmp->username = tmp->password = tmp->db = NULL;
 	tmp->port = 27017;
+	tmp->last_try = 0;
 
 	tmp->host = strndup(host_start, host_end - host_start);
 	if (port_start) {

--- a/mcon/types.h
+++ b/mcon/types.h
@@ -116,6 +116,7 @@ typedef struct _mongo_server_def
 	char *db;
 	char *username;
 	char *password;
+	time_t last_try; /* Contains the time of the last failed connection attempted */
 } mongo_server_def;
 
 typedef struct _mongo_servers


### PR DESCRIPTION
This ensures that the driver doesn't try to reestablish a connection to a down
node at every request.
