### PR TITLE
Initialize last_try as 0 as we check for it when creating new secondary

### DIFF
--- a/mcon/manager.c
+++ b/mcon/manager.c
@@ -113,6 +113,7 @@ static void mongo_discover_topology(mongo_con_manager *manager, mongo_servers *s
 					tmp_def->db = servers->server[i]->db ? strdup(servers->server[i]->db) : NULL;
 					tmp_def->host = strndup(found_hosts[j], strchr(found_hosts[j], ':') - found_hosts[j]);
 					tmp_def->port = atoi(strchr(found_hosts[j], ':') + 1);
+					tmp_def->last_try = 0;
 					
 					/* Create a hash so that we can check whether we already have a
 					 * connection for this server definition. If we don't create


### PR DESCRIPTION
connections (fixes weird results in the logging tests)
