### PR TITLE
Fixed PHP-468 (Undefined behavior calling MongoGridFSFile::write()

### DIFF
--- a/gridfs.c
+++ b/gridfs.c
@@ -1150,9 +1150,12 @@ PHP_METHOD(MongoGridFSFile, write) {
 
   if (!filename) {
     zval **temp;
-    zend_hash_find(HASH_P(file), "filename", strlen("filename")+1, (void**)&temp);
-
-    filename = Z_STRVAL_PP(temp);
+	if (zend_hash_find(HASH_P(file), "filename", strlen("filename")+1, (void**)&temp) == SUCCESS) {
+		filename = Z_STRVAL_PP(temp);
+	} else {
+		zend_throw_exception(mongo_ce_GridFSException, "Cannot find filename", 0 TSRMLS_CC);
+		return;
+	}
   }
 
 

--- a/tests/generic/bug468.phpt
+++ b/tests/generic/bug468.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Test for PHP-468: Undefined behavior calling MongoGridFSFile::write() without a filename
+--SKIPIF--
+<?php require_once dirname(__FILE__) . "/skipif.inc"; ?>
+--FILE--
+<?php
+
+require_once dirname(__FILE__) . "/../utils.inc";
+
+$m = mongo();
+$grid = $m->selectDB(dbname())->getGridFS();
+$id = $grid->storeBytes('foo');
+$file = $grid->get($id);
+try {
+    $file->write();
+} catch(MongoGridFSException $e) {
+    var_dump($e->getMessage());
+}
+?>
+--EXPECTF--
+string(20) "Cannot find filename"
+


### PR DESCRIPTION
without a filename)
