### PR TITLE
Use "..." as reflection name for variable length arguments

### DIFF
--- a/collection.c
+++ b/collection.c
@@ -1586,7 +1586,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_aggregate, 0, 0, 1)
 	ZEND_ARG_INFO(0, pipelines)
 	ZEND_ARG_INFO(0, pipeline)
-	ZEND_ARG_INFO(0, ..)
+	ZEND_ARG_INFO(0, ...)
 ZEND_END_ARG_INFO()
 
 static zend_function_entry MongoCollection_methods[] = {


### PR DESCRIPTION
See: http://php.net/manual/en/language.pseudo-types.php and sebastianbergmann/phpunit#642
