### PR TITLE
Fix arginfo and setReadPreference error tests

### DIFF
--- a/tests/generic/mongodb-setreadpreference_error-002.phpt
+++ b/tests/generic/mongodb-setreadpreference_error-002.phpt
@@ -38,7 +38,7 @@ foreach ($a as $value) {
 ?>
 --EXPECTF--
 int(4096)
-string(81) "Argument 2 passed to MongoDB::setReadPreference() must be an array, integer given"
+string(81) "Argument 2 passed to MongoDB::setReadPreference() must be %s array, integer given"
 
 Warning: MongoDB::setReadPreference() expects parameter 2 to be array, integer given in %s on line %d
 array(2) {
@@ -49,7 +49,7 @@ array(2) {
 }
 ---
 int(4096)
-string(80) "Argument 2 passed to MongoDB::setReadPreference() must be an array, string given"
+string(80) "Argument 2 passed to MongoDB::setReadPreference() must be %s array, string given"
 
 Warning: MongoDB::setReadPreference() expects parameter 2 to be array, string given in %s on line %d
 array(2) {

--- a/tests/others/php-270-arginfo.phpt
+++ b/tests/others/php-270-arginfo.phpt
@@ -148,6 +148,11 @@ MongoCollection
   Method findOne expects 2 parameters
     0: query (optional)
     1: fields (optional)
+  Method findAndModify expects 4 parameters
+    0: query
+    1: update (optional)
+    2: fields (optional)
+    3: options (optional)
   Method ensureIndex expects 2 parameters
     0: key_OR_array_of_keys
     1: options (optional)


### PR DESCRIPTION
The error message language varies between "an" and "of the type", so use "%s" for robustness.
