### PR TITLE
Fixed PHP-493 (raise errors on failure)

### DIFF
--- a/collection.c
+++ b/collection.c
@@ -1267,7 +1267,7 @@ PHP_METHOD(MongoCollection, toIndexString) {
    Wrapper for the aggregate runCommand. Either one array of ops (a pipeline), or a variable number of op arguments */
 PHP_METHOD(MongoCollection, aggregate)
 {
-	zval ***argv, *pipeline, *data, *retval, **values, *tmp;
+	zval ***argv, *pipeline, *data, *retval, **values, *tmp, **tmpvalue;
 	int argc, i;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "+", &argv, &argc) == FAILURE) {
@@ -1316,9 +1316,23 @@ PHP_METHOD(MongoCollection, aggregate)
 	MAKE_STD_ZVAL(retval);
 	MONGO_CMD(retval, c->parent);
 
-	if (zend_hash_find(Z_ARRVAL_P(retval), "result", strlen("result") + 1, (void **) &values) == SUCCESS) {
-		array_init_size(return_value, zend_hash_num_elements(Z_ARRVAL_PP(values)));
-		zend_hash_copy(Z_ARRVAL_P(return_value), Z_ARRVAL_PP(values), (copy_ctor_func_t) zval_add_ref, NULL, sizeof(zval*));
+	if (zend_hash_find(Z_ARRVAL_P(retval), "ok", strlen("ok") + 1, (void **) &tmpvalue) == SUCCESS) {
+		if (Z_LVAL_PP(tmpvalue) < 1) {
+			zval **errmsg;
+			if (zend_hash_find(Z_ARRVAL_P(retval), "errmsg", strlen("errmsg") + 1, (void **) &errmsg) == SUCCESS) {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING, "%s", Z_STRVAL_PP(errmsg));
+			} else {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unkown error executing pipeline");
+			}
+			RETVAL_FALSE;
+		} else {
+			if (zend_hash_find(Z_ARRVAL_P(retval), "result", strlen("result") + 1, (void **) &values) == SUCCESS) {
+				array_init_size(return_value, zend_hash_num_elements(Z_ARRVAL_PP(values)));
+				zend_hash_copy(Z_ARRVAL_P(return_value), Z_ARRVAL_PP(values), (copy_ctor_func_t) zval_add_ref, NULL, sizeof(zval*));
+			} else {
+				RETVAL_FALSE;
+			}
+		}
 	} else {
 		RETVAL_FALSE;
 	}

--- a/tests/generic/mongocollection-aggregate-errors.phpt
+++ b/tests/generic/mongocollection-aggregate-errors.phpt
@@ -1,0 +1,77 @@
+--TEST--
+MongoCollection::aggregate() basic tests
+--SKIPIF--
+<?php $needs = "2.1.0"; require __DIR__ . "/skipif.inc" ?>
+--INI--
+error_reporting=-1
+display_errors=1
+--FILE--
+<?php
+require_once __DIR__ . "/../utils.inc";
+
+$m = mongo();
+$c = $m->selectDB("phpunit")->selectCollection("article");
+$c->drop();
+$data = array (
+    'title' => 'this is my title',
+    'author' => 'bob',
+    'posted' => new MongoDate,
+    'pageViews' => 5,
+    'tags' => 
+    array (
+      0 => 'fun',
+      1 => 'good',
+      2 => 'fun',
+    ),
+    'comments' => 
+    array (
+      0 => 
+      array (
+        'author' => 'joe',
+        'text' => 'this is cool',
+      ),
+      1 => 
+      array (
+        'author' => 'sam',
+        'text' => 'this is bad',
+      ),
+    ),
+    'other' => 
+    array (
+      'foo' => 5,
+    ),
+);
+$d = $c->insert($data, array("safe" => true));
+
+$ops = array(
+    array(
+        '$project' => array(
+            "author" => 1,
+            "tags"   => 1,
+        )
+    ),
+    array('$unwind' => '$tags'),
+    array(
+        '$group' => array(
+            "_id" => array("tags" => '$tags'),
+            "authors" => array('addToSet' => '$author'),
+        )
+    )
+);
+
+
+$alone = $c->aggregate($ops);
+$multiple = $c->aggregate(current($ops), next($ops), next($ops));
+var_dump($alone, $multiple);
+$c->drop();
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+Warning: MongoCollection::aggregate(): exception: unknown group operator 'addToSet' in %s on line %d
+
+Warning: MongoCollection::aggregate(): exception: unknown group operator 'addToSet' in %s on line %d
+bool(false)
+bool(false)
+===DONE===


### PR DESCRIPTION
I don't like the idea that the end user is exposed to the internal structure of the result document.
We should be detecting errors and displaying the appropriate errormessages instead on failure.

This patch fixes PHP-493 by checking the ok field and populating an error with the errormessage from the server, in case of errors.

The return value hasn't change, the user gets just the 'result' embedded document.
