### PR TITLE
Supporting the LCOV v1.10

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -55,7 +55,7 @@ if test "$PHP_COVERAGE" = "yes"; then
     AC_MSG_ERROR([ccache must be disabled when --enable-coverage option is used. You can disable ccache by setting environment variable CCACHE_DISABLE=1.])
   fi
   
-  lcov_version_list="1.5 1.6 1.7 1.9"
+  lcov_version_list="1.5 1.6 1.7 1.9 1.10"
 
   AC_CHECK_PROG(LCOV, lcov, lcov)
   AC_CHECK_PROG(GENHTML, genhtml, genhtml)


### PR DESCRIPTION
```
checking for lcov version... invalid
configure: error: You must have one of the following versions of LCOV: 1.5 1.6 1.7 1.9 (found: 1.10).
make: *** No rule to make target `all'.  Stop.
```

https://jenkins.10gen.com/job/mongo-php-driver/mongodb_configuration=single_server,mongodb_server=stable-release,os_arch=linux64,php_language_version=5.3/63/console
