### PR TITLE
Fixed PHP-629: Missing support for passing the username/password in the ...

### DIFF
--- a/mcon/parse.c
+++ b/mcon/parse.c
@@ -349,6 +349,10 @@ int mongo_store_option(mongo_con_manager *manager, mongo_servers *servers, char 
 				free(servers->server[i]->username);
 			}
 			servers->server[i]->username = strdup(option_value);
+			/* Use "admin" as the default db if none selected yet */
+			if (!servers->server[i]->db) {
+				servers->server[i]->db = strdup("admin");
+			}
 		}
 		return 0;
 	}

--- a/tests/replicaset-auth/bug00629.phpt
+++ b/tests/replicaset-auth/bug00629.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Test for PHP-629
+--SKIPIF--
+<?php require_once dirname(__FILE__) . "/skipif.inc"; ?>
+--FILE--
+<?php
+require_once dirname(__FILE__) . "/../utils.inc";
+
+$options = array(
+        'connect'    => true,
+        'timeout'    => 5000,
+        'replicaSet' => rsname(),
+        'username'   => username("admin"),
+        'password'   => password("admin"),
+);
+
+$mongoDbClient = new MongoClient('mongodb://' . hostname(), $options);
+
+$database = $mongoDbClient->selectDB('admin');
+$command = "db.version()";
+$response = $database->execute($command);
+var_dump($response);
+?>
+--EXPECTF--
+array(2) {
+  ["retval"]=>
+  string(%s) "%s"
+  ["ok"]=>
+  float(1)
+}
+


### PR DESCRIPTION
...$options array

If we don't set a database we don't notice this is supposed to be an
authenticated connections.
Since `ismaster` commands don't require authentication we can get an
valid connection back, but since its not authenticated it'll fail on
first query/command.
