### PR TITLE
Fixed PHP-634: Mongo PHP v1.3 fails w/mongoDB 1.6

### DIFF
--- a/mcon/connections.c
+++ b/mcon/connections.c
@@ -603,9 +603,9 @@ int mongo_connection_get_server_flags(mongo_con_manager *manager, mongo_connecti
 		mongo_manager_log(manager, MLOG_CON, MLOG_FINE, "get_server_flags: setting maxBsonObjectSize to %d", max_bson_size);
 		con->max_bson_size = max_bson_size;
 	} else {
-		*error_message = strdup("Couldn't find the maxBsonObjectSize field");
-		free(data_buffer);
-		return 0;
+		/* This seems to be very old MongoDB installation (PHP-634).. Default to 4MB */
+		con->max_bson_size = 4194304;
+		mongo_manager_log(manager, MLOG_CON, MLOG_FINE, "get_server_flags: can't find maxBsonObjectSize.. guesstimating %d", con->max_bson_size);
 	}
 
 	/* Find msg and whether it contains "isdbgrid" */


### PR DESCRIPTION
Oooold versions (1.6.x f.e.) of MongoDB do not include the
maxBsonObjectSize field in the ismaster response (or at all
for that matter). To support those versions we need to have an default
value, 4mb (better be safe then sorry here!) C# and other drivers
use the same value as their defaults.

Surprisingly enough, all the standalone tests pass just fine - with
the exception of reordered associative array keys, different error
messages, and missing features.

This _SHOULD_ be merged into 1.3.2
