### PR TITLE
Fixed PHP-623: Make MD5 functions static, and only visible in the utils.c file

### DIFF
--- a/mcon/utils.c
+++ b/mcon/utils.c
@@ -174,9 +174,18 @@ int mongo_server_hash_to_pid(char *hash)
 }
 
 /* Forward declaration for the MD5 algorithm */
-void MD5_Init(MD5_CTX *ctx);
-void MD5_Update(MD5_CTX *ctx, void *data, unsigned long size);
-void MD5_Final(unsigned char *result, MD5_CTX *ctx);
+typedef unsigned int MD5_u32plus;
+ 
+typedef struct {
+	MD5_u32plus lo, hi;
+	MD5_u32plus a, b, c, d;
+	unsigned char buffer[64];
+	MD5_u32plus block[16];
+} MD5_CTX;
+
+static void MD5_Init(MD5_CTX *ctx);
+static void MD5_Update(MD5_CTX *ctx, void *data, unsigned long size);
+static void MD5_Final(unsigned char *result, MD5_CTX *ctx);
 
 /* Convience function around the MD5 implementation */
 char *mongo_util_md5_hex(char *hash, int hash_length)
@@ -393,7 +402,7 @@ static void *body(MD5_CTX *ctx, void *data, unsigned long size)
 	return ptr;
 }
  
-void MD5_Init(MD5_CTX *ctx)
+static void MD5_Init(MD5_CTX *ctx)
 {
 	ctx->a = 0x67452301;
 	ctx->b = 0xefcdab89;
@@ -404,7 +413,7 @@ void MD5_Init(MD5_CTX *ctx)
 	ctx->hi = 0;
 }
  
-void MD5_Update(MD5_CTX *ctx, void *data, unsigned long size)
+static void MD5_Update(MD5_CTX *ctx, void *data, unsigned long size)
 {
 	MD5_u32plus saved_lo;
 	unsigned long used, free;
@@ -438,7 +447,7 @@ void MD5_Update(MD5_CTX *ctx, void *data, unsigned long size)
 	memcpy(ctx->buffer, data, size);
 }
  
-void MD5_Final(unsigned char *result, MD5_CTX *ctx)
+static void MD5_Final(unsigned char *result, MD5_CTX *ctx)
 {
 	unsigned long used, free;
  

--- a/mcon/utils.h
+++ b/mcon/utils.h
@@ -23,42 +23,6 @@ char *mongo_server_create_hash(mongo_server_def *server_def);
 int mongo_server_split_hash(char *hash, char **host, int *port, char **repl_set_name, char **database, char **username, char **auth_hash, int *pid);
 char *mongo_server_hash_to_server(char *hash);
 int mongo_server_hash_to_pid(char *hash);
-
-/*
- * This is an OpenSSL-compatible implementation of the RSA Data Security, Inc.
- * MD5 Message-Digest Algorithm (RFC 1321).
- *
- * Homepage:
- * http://openwall.info/wiki/people/solar/software/public-domain-source-code/md5
- *
- * Author:
- * Alexander Peslyak, better known as Solar Designer <solar at openwall.com>
- *
- * This software was written by Alexander Peslyak in 2001.  No copyright is
- * claimed, and the software is hereby placed in the public domain.
- * In case this attempt to disclaim copyright and place the software in the
- * public domain is deemed null and void, then the software is
- * Copyright (c) 2001 Alexander Peslyak and it is hereby released to the
- * general public under the following terms:
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted.
- *
- * There's ABSOLUTELY NO WARRANTY, express or implied.
- *
- * See utils.c for more information.
- */
- 
-/* Any 32-bit or wider unsigned integer data type will do */
-typedef unsigned int MD5_u32plus;
- 
-typedef struct {
-	MD5_u32plus lo, hi;
-	MD5_u32plus a, b, c, d;
-	unsigned char buffer[64];
-	MD5_u32plus block[16];
-} MD5_CTX;
- 
 char *mongo_util_md5_hex(char *hash, int hash_length);
 
 /*


### PR DESCRIPTION
We did not properly name-space protect the MD5_\* functions. In case they were
already defined the linker might pick up the wrong ones. That is likely to
happen in case libcrypto is also available in the process' address space. By
making them static and removing all references in the .h file, their use in the
driver is contained.
