### PR TITLE
Fixed PHP-635: The second argument to MongoCursor::__construct() always gets converted to a string.

### DIFF
--- a/cursor.c
+++ b/cursor.c
@@ -222,14 +222,16 @@ int php_mongo_get_reply(mongo_cursor *cursor, zval *errmsg TSRMLS_DC)
 /* {{{ MongoCursor->__construct
  */
 PHP_METHOD(MongoCursor, __construct) {
-  zval *zlink = 0, *zns = 0, *zquery = 0, *zfields = 0, *empty, *timeout;
+	zval *zlink = 0, *zquery = 0, *zfields = 0, *empty, *timeout;
+	char *ns;
+	int   ns_len;
   zval **data;
   mongo_cursor *cursor;
 
-  if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Oz|zz", &zlink,
-                            mongo_ce_MongoClient, &zns, &zquery, &zfields) == FAILURE) {
-    return;
-  }
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Os|zz", &zlink, mongo_ce_MongoClient, &ns, &ns_len, &zquery, &zfields) == FAILURE) {
+		return;
+	}
+
   MUST_BE_ARRAY_OR_OBJECT(3, zquery);
   MUST_BE_ARRAY_OR_OBJECT(4, zfields);
 
@@ -299,9 +301,8 @@ PHP_METHOD(MongoCursor, __construct) {
     zval_add_ref(&zfields);
   }
 
-  // ns
-  convert_to_string(zns);
-  cursor->ns = estrdup(Z_STRVAL_P(zns));
+	/* ns */
+	cursor->ns = estrdup(ns);
 
   // query
   cursor->query = zquery;

--- a/tests/generic/bug00635.phpt
+++ b/tests/generic/bug00635.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Test for PHP-635: The second argument to MongoCursor::__construct() always gets converted to a string.
+--SKIPIF--
+<?php require_once __DIR__ . "/skipif.inc"; ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils.inc";
+
+$m = mongo();
+$collection = $m->selectDb(dbname())->bug635;
+var_dump($collection);
+ 
+$cursor = new MongoCursor($m, $collection);
+var_dump($collection);
+var_dump(is_object($collection));
+?>
+--EXPECTF--
+object(MongoCollection)#%d (%d) {
+  ["w"]=>
+  int(0)
+  ["wtimeout"]=>
+  int(10000)
+}
+object(MongoCollection)#%d (%d) {
+  ["w"]=>
+  int(0)
+  ["wtimeout"]=>
+  int(10000)
+}
+bool(true)


### PR DESCRIPTION
The code just blindly converted it to a string. If you only want to temporarily convert things (like we want here), then you need to use the convert_to_*_ex functions.
