### PR TITLE
Fixed PHP-641: MongoLog::setModule/setLevel don't reset for each request

### DIFF
--- a/php_mongo.c
+++ b/php_mongo.c
@@ -278,8 +278,6 @@ static PHP_GINIT_FUNCTION(mongo)
 
   mongo_globals->ts_inc = 0;
 
-	mongo_globals->log_level = 0;
-	mongo_globals->log_module = 0;
 #if PHP_VERSION_ID >= 50300
 	mongo_globals->log_callback_info = empty_fcall_info;
 	mongo_globals->log_callback_info_cache = empty_fcall_info_cache;
@@ -318,6 +316,9 @@ PHP_MSHUTDOWN_FUNCTION(mongo) {
  */
 PHP_RINIT_FUNCTION(mongo)
 {
+	MonGlo(log_level) = 0;
+	MonGlo(log_module) = 0;
+
 	return SUCCESS;
 }
 /* }}} */


### PR DESCRIPTION
They were only reset in GINIT, which is once per thread (in a threaded
environment) or per process (in a non threaded environment).  Moving the
initialisation to MINIT fixes this. setCallback() is not affected as it is a
property of the MongoLog class.
