### PR TITLE
Fixed PHP-375: GridFS segfaults when there are more chunks than expected

### DIFF
--- a/gridfs.c
+++ b/gridfs.c
@@ -83,7 +83,7 @@ static int copy_bytes(void *to, char *from, int len);
 static int copy_file(void *to, char *from, int len);
 static void add_md5(zval *zfile, zval *zid, mongo_collection *c TSRMLS_DC);
 
-static int apply_to_cursor(zval *cursor, apply_copy_func_t apply_copy_func, void *to TSRMLS_DC);
+static int apply_to_cursor(zval *cursor, apply_copy_func_t apply_copy_func, void *to, int max TSRMLS_DC);
 static int setup_file(FILE *fpp, char *filename TSRMLS_DC);
 static int get_chunk_size(zval *array TSRMLS_DC);
 static zval* setup_extra(zval *zfile, zval *extra TSRMLS_DC);
@@ -1231,7 +1231,7 @@ PHP_METHOD(MongoGridFSFile, write) {
 
   MONGO_METHOD1(MongoCursor, sort, cursor, cursor, sort);
 
-  if ((total = apply_to_cursor(cursor, copy_file, fp TSRMLS_CC)) == FAILURE) {
+  if ((total = apply_to_cursor(cursor, copy_file, fp, 0 TSRMLS_CC)) == FAILURE) {
     zend_throw_exception(mongo_ce_GridFSException, "error reading chunk of file", 0 TSRMLS_CC);
   }
 
@@ -1317,7 +1317,7 @@ PHP_METHOD(MongoGridFSFile, getBytes) {
   str = (char*)emalloc(len + 1);
   str_ptr = str;
 
-  if (apply_to_cursor(cursor, copy_bytes, &str TSRMLS_CC) == FAILURE) {
+  if (apply_to_cursor(cursor, copy_bytes, &str, len + 1 TSRMLS_CC) == FAILURE) {
       if (EG(exception)) {
           return;
       }
@@ -1351,7 +1351,7 @@ static int copy_file(void *to, char *from, int len) {
   return written;
 }
 
-static int apply_to_cursor(zval *cursor, apply_copy_func_t apply_copy_func, void *to TSRMLS_DC) {
+static int apply_to_cursor(zval *cursor, apply_copy_func_t apply_copy_func, void *to, int max TSRMLS_DC) {
   int total = 0;
   zval *next;
 
@@ -1380,12 +1380,26 @@ static int apply_to_cursor(zval *cursor, apply_copy_func_t apply_copy_func, void
      */
     // raw bytes
     if (Z_TYPE_PP(zdata) == IS_STRING) {
+		if (total + Z_STRLEN_PP(zdata) > max) {
+			zend_throw_exception_ex(mongo_ce_GridFSException, 17 TSRMLS_CC, "Chunk larger then expected");
+			return FAILURE;
+		}
       total += apply_copy_func(to, Z_STRVAL_PP(zdata), Z_STRLEN_PP(zdata));
     }
     // MongoBinData
     else if (Z_TYPE_PP(zdata) == IS_OBJECT &&
              Z_OBJCE_PP(zdata) == mongo_ce_BinData) {
       zval *bin = zend_read_property(mongo_ce_BinData, *zdata, "bin", strlen("bin"), NOISY TSRMLS_CC);
+		if (total + Z_STRLEN_P(bin) > max) {
+			zval **n;
+			if (zend_hash_find(HASH_P(next), "n", strlen("n")+1, (void**)&n) == SUCCESS) {
+				convert_to_long_ex(n);
+				zend_throw_exception_ex(mongo_ce_GridFSException, 17 TSRMLS_CC, "Chunk#%d larger then expected", Z_LVAL_PP(n));
+			} else {
+				zend_throw_exception_ex(mongo_ce_GridFSException, 17 TSRMLS_CC, "Chunk larger then expected");
+			}
+			return FAILURE;
+		}
       total += apply_copy_func(to, Z_STRVAL_P(bin), Z_STRLEN_P(bin));
     }
     // if it's not a string or a MongoBinData, give up

--- a/tests/generic/bug00375.phpt
+++ b/tests/generic/bug00375.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Test for PHP-375: GridFS segfaults when there are more chunks than expected
+--SKIPIF--
+<?php require_once dirname(__FILE__) . "/skipif.inc"; ?>
+--FILE--
+<?php
+require_once dirname(__FILE__) . "/../utils.inc";
+
+$m = new_mongo();
+$gridfs = $m->selectDb(dbname())->getGridfs();
+
+
+$id = $gridfs->put(__FILE__);
+$coll = $m->selectDB(dbname())->selectCollection("fs.chunks");
+
+// Fetch the first (only) chunk
+$chunk = $coll->find(array("files_id" => $id))->getNext();
+// Unset the id and bump the chunk# to create unexpectedly many chunks
+unset($chunk["_id"]);
+$chunk["n"]++;
+$coll->insert($chunk);
+
+
+// Now fetch the inserted file
+$file = $gridfs->findOne(array("_id" => $id));
+
+// Throws exception about to many chunks
+try {
+    $file->getBytes();
+} catch(MongoGridFSException $e) {
+    var_dump($e->getMessage(), $e->getCode());
+}
+?>
+--EXPECTF--
+string(28) "Chunk#1 larger then expected"
+int(17)
+


### PR DESCRIPTION
We cannot blindly trust the size receieved from the files collection.
We need to track the data we are actually reading and copying into
memory so we don't try to stuff to much data in - invalid data even.
