### PR TITLE
[PHP-627] Allow single pipeline operator arg in MongoCollection::aggregate()

### DIFF
--- a/collection.c
+++ b/collection.c
@@ -1400,7 +1400,11 @@ PHP_METHOD(MongoCollection, aggregate)
 	add_assoc_zval(data, "aggregate", c->name);
 	zval_add_ref(&c->name);
 
-	if (argc == 1) {
+	/* If the single array argument contains a zeroth index, consider it an
+	 * array of pipeline operators. Otherwise, assume it is a single pipeline
+	 * operator and allow it to be wrapped in an array.
+	 */
+	if (argc == 1 && zend_hash_index_exists(Z_ARRVAL_PP(argv[0]), 0)) {
 		Z_ADDREF_PP(*argv);
 		add_assoc_zval(data, "pipeline", **argv);
 	} else {

--- a/tests/generic/bug00627.phpt
+++ b/tests/generic/bug00627.phpt
@@ -1,0 +1,47 @@
+--TEST--
+Test for PHP-627: MongoConnection::aggregate() breaks on single pipeline operator argument
+--SKIPIF--
+<?php require_once __DIR__ . "/skipif.inc"; ?>
+--FILE--
+<?php
+require_once __DIR__ . "/../utils.inc";
+
+$m = mongo();
+$c = $m->selectCollection(dbname(), 'bug627');
+$c->drop();
+
+foreach (range(1,5) as $x) {
+    $c->insert(array('x' => $x));
+}
+
+$group = array('$group' => array('_id' => 1, 'count' => array('$sum' => 1)));
+$project = array('$project' => array('count' => 1));
+
+$rs1 = $c->aggregate($group);
+$rs2 = $c->aggregate(array($group));
+$rs3 = $c->aggregate($group, $project);
+$rs4 = $c->aggregate(array($group, $project));
+
+var_dump($rs1 === $rs2);
+var_dump($rs2 === $rs3);
+var_dump($rs3 === $rs4);
+var_dump($rs1);
+
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+array(2) {
+  ["result"]=>
+  array(1) {
+    [0]=>
+    array(2) {
+      ["_id"]=>
+      int(1)
+      ["count"]=>
+      int(5)
+    }
+  }
+  ["ok"]=>
+  float(1)
+}


### PR DESCRIPTION
See: https://jira.mongodb.org/browse/PHP-627

When running standalone tests (ignoring sharding and replica sets):

```
=====================================================================
FAILED TEST SUMMARY
---------------------------------------------------------------------
Test for PHP-207: setSlaveOkay not supported for GridFS queries [tests/generic/bug00207.phpt]
MongoGridFSFile::write() [tests/generic/mongogridfsfile-write-001.phpt]
Test for PHP-270: ext/mongo classes should return meaningful results from Reflection API [tests/others/bug00270-arginfo.phpt]
Test for MongoLog [tests/standalone/log-1.phpt]
Test for MongoLog (connection only) [tests/standalone/log-2.phpt]
Test for MongoLog (level variations) [tests/standalone/log-4.phpt]
=====================================================================
```
