### PR TITLE
Fixed MongoDate serialisation and deserialisation with negative timestamps.

### DIFF
--- a/bson.c
+++ b/bson.c
@@ -1021,12 +1021,14 @@ char* bson_to_zval(char *buf, HashTable *result TSRMLS_DC) {
     }
     case BSON_DATE: {
       int64_t d = MONGO_64(*((int64_t*)buf));
+			long n;
       buf += INT_64;
 
       object_init_ex(value, mongo_ce_Date);
 
-      zend_update_property_long(mongo_ce_Date, value, "sec", strlen("sec"), (long)(d/1000) TSRMLS_CC);
-      zend_update_property_long(mongo_ce_Date, value, "usec", strlen("usec"), (long)((d*1000)%1000000) TSRMLS_CC);
+			zend_update_property_long(mongo_ce_Date, value, "sec", strlen("sec"), (long) (d/1000) - (d < 0) TSRMLS_CC);
+			n = (long) (d*1000);
+			zend_update_property_long(mongo_ce_Date, value, "usec", strlen("usec"), ((n % 1000000) + 1000000) % 1000000 TSRMLS_CC);
 
       break;
     }

--- a/tests/generic/mongodate-008.phpt
+++ b/tests/generic/mongodate-008.phpt
@@ -124,11 +124,11 @@ object(MongoDate)#%d (%d) {
 0.08123400 -1000
 object(MongoDate)#%d (%d) {
   ["sec"]=>
-  int(-999)
+  int(-1000)
   ["usec"]=>
-  int(-919000)
+  int(81000)
 }
--0.91900000 -999
+0.08100000 -1000
 
 -1000, 801234
 object(MongoDate)#%d (%d) {
@@ -140,11 +140,11 @@ object(MongoDate)#%d (%d) {
 0.80123400 -1000
 object(MongoDate)#%d (%d) {
   ["sec"]=>
-  int(-999)
+  int(-1000)
   ["usec"]=>
-  int(-199000)
+  int(801000)
 }
--0.19900000 -999
+0.80100000 -1000
 
 -1000, 8001234
 object(MongoDate)#%d (%d) {
@@ -156,11 +156,11 @@ object(MongoDate)#%d (%d) {
 8.00123400 -1000
 object(MongoDate)#%d (%d) {
   ["sec"]=>
-  int(-991)
+  int(-992)
   ["usec"]=>
-  int(-999000)
+  int(1000)
 }
--0.99900000 -991
+0.00100000 -992
 
 -1000, -81234
 object(MongoDate)#%d (%d) {
@@ -172,11 +172,11 @@ object(MongoDate)#%d (%d) {
 -0.08123400 -1000
 object(MongoDate)#%d (%d) {
   ["sec"]=>
-  int(-1000)
+  int(-1001)
   ["usec"]=>
-  int(-81000)
+  int(919000)
 }
--0.08100000 -1000
+0.91900000 -1001
 
 -1000, -801234
 object(MongoDate)#%d (%d) {
@@ -188,11 +188,11 @@ object(MongoDate)#%d (%d) {
 -0.80123400 -1000
 object(MongoDate)#%d (%d) {
   ["sec"]=>
-  int(-1000)
+  int(-1001)
   ["usec"]=>
-  int(-801000)
+  int(199000)
 }
--0.80100000 -1000
+0.19900000 -1001
 
 -1000, -8001234
 object(MongoDate)#%d (%d) {
@@ -204,11 +204,11 @@ object(MongoDate)#%d (%d) {
 -8.00123400 -1000
 object(MongoDate)#%d (%d) {
   ["sec"]=>
-  int(-1008)
+  int(-1009)
   ["usec"]=>
-  int(-1000)
+  int(999000)
 }
--0.00100000 -1008
+0.99900000 -1009
 
 1000, 81234
 object(MongoDate)#%d (%d) {

--- a/tests/others/mongodate-007.phpt
+++ b/tests/others/mongodate-007.phpt
@@ -113,11 +113,11 @@ object(MongoDate)#%d (%d) {
 0.08123400 -1000
 object(MongoDate)#%d (%d) {
   ["sec"]=>
-  int(-999)
+  int(-1000)
   ["usec"]=>
-  int(-919000)
+  int(81000)
 }
--0.91900000 -999
+0.08100000 -1000
 
 -1000, 801234
 object(MongoDate)#%d (%d) {
@@ -129,11 +129,11 @@ object(MongoDate)#%d (%d) {
 0.80123400 -1000
 object(MongoDate)#%d (%d) {
   ["sec"]=>
-  int(-999)
+  int(-1000)
   ["usec"]=>
-  int(-199000)
+  int(801000)
 }
--0.19900000 -999
+0.80100000 -1000
 
 -1000, 8001234
 object(MongoDate)#%d (%d) {
@@ -145,11 +145,11 @@ object(MongoDate)#%d (%d) {
 8.00123400 -1000
 object(MongoDate)#%d (%d) {
   ["sec"]=>
-  int(-991)
+  int(-992)
   ["usec"]=>
-  int(-999000)
+  int(1000)
 }
--0.99900000 -991
+0.00100000 -992
 
 -1000, -81234
 object(MongoDate)#%d (%d) {
@@ -161,11 +161,11 @@ object(MongoDate)#%d (%d) {
 -0.08123400 -1000
 object(MongoDate)#%d (%d) {
   ["sec"]=>
-  int(-1000)
+  int(-1001)
   ["usec"]=>
-  int(-81000)
+  int(919000)
 }
--0.08100000 -1000
+0.91900000 -1001
 
 -1000, -801234
 object(MongoDate)#%d (%d) {
@@ -177,11 +177,11 @@ object(MongoDate)#%d (%d) {
 -0.80123400 -1000
 object(MongoDate)#%d (%d) {
   ["sec"]=>
-  int(-1000)
+  int(-1001)
   ["usec"]=>
-  int(-801000)
+  int(199000)
 }
--0.80100000 -1000
+0.19900000 -1001
 
 -1000, -8001234
 object(MongoDate)#%d (%d) {
@@ -193,11 +193,11 @@ object(MongoDate)#%d (%d) {
 -8.00123400 -1000
 object(MongoDate)#%d (%d) {
   ["sec"]=>
-  int(-1008)
+  int(-1009)
   ["usec"]=>
-  int(-1000)
+  int(999000)
 }
--0.00100000 -1008
+0.99900000 -1009
 
 1000, 81234
 object(MongoDate)#%d (%d) {


### PR DESCRIPTION
Apparently MongoDB uses the Euclidean modulo operator instead of C's truncated
modulo operator. This is difficult to test automatically, as calling out to the
mongo shell is impractical.

I have tested with a range of numbers, including ones close to the Epoch.
