### PR TITLE
Fixed PHP-479: Compiler warnings

### DIFF
--- a/bson.c
+++ b/bson.c
@@ -166,7 +166,7 @@ static int apply_func_args_wrapper(void **data, int num_args, va_list args, zend
   }
 }
 
-int php_mongo_serialize_element(char *name, zval **data, buffer *buf, int prep TSRMLS_DC) {
+int php_mongo_serialize_element(const char *name, zval **data, buffer *buf, int prep TSRMLS_DC) {
   int name_len = strlen(name);
 
   if (prep && strcmp(name, "_id") == 0) {
@@ -562,7 +562,7 @@ void php_mongo_serialize_double(buffer *buf, double num) {
  * prep == true
  *    we are inserting, so keys can't have .s in them
  */
-void php_mongo_serialize_key(buffer *buf, char *str, int str_len, int prep TSRMLS_DC) {
+void php_mongo_serialize_key(buffer *buf, const char *str, int str_len, int prep TSRMLS_DC) {
   if (str[0] == '\0' && !MonGlo(allow_empty_keys)) {
     zend_throw_exception_ex(mongo_ce_Exception, 1 TSRMLS_CC, "zero-length keys are not allowed, did you use $ with double quotes?");
     return;

--- a/bson.h
+++ b/bson.h
@@ -51,7 +51,7 @@
 int php_mongo_serialize_size(char *start, buffer *buf TSRMLS_DC);
 
 /* driver */
-int php_mongo_serialize_element(char*, zval**, buffer*, int TSRMLS_DC);
+int php_mongo_serialize_element(const char*, zval**, buffer*, int TSRMLS_DC);
 
 /* objects */
 void php_mongo_serialize_date(buffer*, zval* TSRMLS_DC);
@@ -69,7 +69,7 @@ void php_mongo_serialize_long(buffer*, int64_t);
 void php_mongo_serialize_int(buffer*, int);
 void php_mongo_serialize_byte(buffer*, char);
 void php_mongo_serialize_bytes(buffer*, char*, int);
-void php_mongo_serialize_key(buffer*, char*, int, int TSRMLS_DC);
+void php_mongo_serialize_key(buffer*, const char*, int, int TSRMLS_DC);
 void php_mongo_serialize_ns(buffer*, char* TSRMLS_DC);
 
 int php_mongo_write_insert(buffer*, char*, zval*, int max TSRMLS_DC);

--- a/collection.c
+++ b/collection.c
@@ -1819,7 +1819,7 @@ static int php_mongo_trigger_error_on_command_failure(zval *document TSRMLS_DC)
 /* {{{ php_mongo_collection_new
  */
 zend_object_value php_mongo_collection_new(zend_class_entry *class_type TSRMLS_DC) {
-  php_mongo_obj_new(mongo_collection);
+	PHP_MONGO_OBJ_NEW(mongo_collection);
 }
 /* }}} */
 

--- a/cursor.c
+++ b/cursor.c
@@ -227,7 +227,6 @@ PHP_METHOD(MongoCursor, __construct) {
 	int   ns_len;
   zval **data;
   mongo_cursor *cursor;
-	mongoclient *link;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "Os|zz", &zlink, mongo_ce_MongoClient, &ns, &ns_len, &zquery, &zfields) == FAILURE) {
 		return;
@@ -1797,7 +1796,7 @@ static void kill_cursor(cursor_node *node, zend_rsrc_list_entry *le TSRMLS_DC) {
 
 
 static zend_object_value php_mongo_cursor_new(zend_class_entry *class_type TSRMLS_DC) {
-  php_mongo_obj_new(mongo_cursor);
+	PHP_MONGO_OBJ_NEW(mongo_cursor);
 }
 
 

--- a/db.c
+++ b/db.c
@@ -959,7 +959,7 @@ static void php_mongo_db_free(void *object TSRMLS_DC) {
 /* {{{ mongo_mongo_db_new
  */
 zend_object_value php_mongo_db_new(zend_class_entry *class_type TSRMLS_DC) {
-  php_mongo_obj_new(mongo_db);
+	PHP_MONGO_OBJ_NEW(mongo_db);
 }
 /* }}} */
 

--- a/gridfs.c
+++ b/gridfs.c
@@ -420,7 +420,7 @@ PHP_METHOD(MongoGridFS, storeBytes) {
   char *bytes = 0;
   int bytes_len = 0, chunk_num = 0, chunk_size = 0, global_chunk_size = 0,
     pos = 0;
-	int revert = 0, code = 0;
+	int revert = 0;
 
   zval temp;
   zval *extra = 0, *zid = 0, *zfile = 0, *chunks = 0, *options = 0;

--- a/mongo_types.c
+++ b/mongo_types.c
@@ -165,7 +165,6 @@ static void php_mongo_id_free(void *object TSRMLS_DC) {
 static zend_object_value php_mongo_id_new(zend_class_entry *class_type TSRMLS_DC) {
   zend_object_value retval;
   mongo_id *intern;
-  zval *tmp;
 
   intern = (mongo_id*)emalloc(sizeof(mongo_id));
   memset(intern, 0, sizeof(mongo_id));

--- a/mongoclient.c
+++ b/mongoclient.c
@@ -43,7 +43,6 @@
 
 
 static void php_mongoclient_free(void* TSRMLS_DC);
-static void run_err(int, zval*, zval* TSRMLS_DC);
 static void stringify_server(mongo_server_def *server, smart_str *str);
 static int close_connection(mongo_con_manager *manager, mongo_connection *connection);
 
@@ -225,7 +224,6 @@ zend_object_value php_mongoclient_new(zend_class_entry *class_type TSRMLS_DC)
 {
 	zend_object_value retval;
 	mongoclient *intern;
-	zval *tmp;
 
 	intern = (mongoclient*)emalloc(sizeof(mongoclient));
 	memset(intern, 0, sizeof(mongoclient));

--- a/php_mongo.h
+++ b/php_mongo.h
@@ -248,10 +248,9 @@
     (void *) &tmp, sizeof(zval *))
 #endif
 
-#define php_mongo_obj_new(mongo_obj)                    \
+#define PHP_MONGO_OBJ_NEW(mongo_obj)                    \
   zend_object_value retval;                             \
   mongo_obj *intern;                                    \
-  zval *tmp;                                            \
                                                         \
   intern = (mongo_obj*)emalloc(sizeof(mongo_obj));               \
   memset(intern, 0, sizeof(mongo_obj));                          \

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
+export CFLAGS=-Wall
 phpize && ./configure && make clean && make -j 5 all && make install


### PR DESCRIPTION
I've also added the forcing of -Wall to the ./rebuild.sh script. Please use
that so that we catch compiler warnings in the future before committing.
