### PR TITLE
Fixed PHP-586: GridFS should only do one GLE

### DIFF
--- a/gridfs.c
+++ b/gridfs.c
@@ -424,7 +424,6 @@ PHP_METHOD(MongoGridFS, storeBytes) {
 
   zval temp;
   zval *extra = 0, *zid = 0, *zfile = 0, *chunks = 0, *options = 0;
-  zval **z_safe;
 	zval *cleanup_ids;
 	zval *chunk_id = NULL;
 
@@ -467,16 +466,6 @@ PHP_METHOD(MongoGridFS, storeBytes) {
 		zval_add_ref(&options);
 	}
 
-	// force safe mode
-	if (zend_hash_find(Z_ARRVAL_P(options), "safe", strlen("safe")+1, (void**)&z_safe) == SUCCESS) {
-		convert_to_long_ex(z_safe);
-		if (Z_LVAL_PP(z_safe) < 1) {
-			add_assoc_long(options, "safe", 1);
-		}
-	} else {
-		add_assoc_long(options, "safe", 1);
-	}
-
   // insert chunks
   while (pos < bytes_len) {
     chunk_size = bytes_len-pos >= global_chunk_size ? global_chunk_size : bytes_len-pos;
@@ -497,6 +486,36 @@ PHP_METHOD(MongoGridFS, storeBytes) {
     pos += chunk_size;
     chunk_num++;
   }
+
+
+	/* Run GLE, just to ensure all the data has been written */
+	{
+		zval *data, *gle_retval;
+		MAKE_STD_ZVAL(data);
+		array_init(data);
+
+		add_assoc_long(data, "getlasterror", 1);
+
+		MAKE_STD_ZVAL(gle_retval);
+		ZVAL_NULL(gle_retval);
+
+		// run command
+		MONGO_CMD(gle_retval, c->parent);
+
+		if (Z_TYPE_P(gle_retval) == IS_ARRAY) {
+			zval **err;
+			if (zend_hash_find(Z_ARRVAL_P(gle_retval), "err", strlen("err")+1, (void**)&err) == SUCCESS && Z_TYPE_PP(err) == IS_STRING) {
+				zend_throw_exception_ex(mongo_ce_GridFSException, 0 TSRMLS_CC, Z_STRVAL_PP(err));
+				/* Intentionally not returning, the exception is checked a line later */
+			}
+		}
+		zval_ptr_dtor(&data);
+		zval_ptr_dtor(&gle_retval);
+		if (EG(exception)) {
+			revert = 1;
+			goto cleanup_on_failure;
+		}
+	}
 
   // now that we've inserted the chunks, use them to calculate the hash
   add_md5(zfile, zid, c TSRMLS_CC);
@@ -620,13 +639,12 @@ static zval* insert_chunk(zval *chunks, zval *zid, int chunk_num, char *buf, int
 PHP_METHOD(MongoGridFS, storeFile) {
   zval *fh, *extra = 0, *options = 0;
   char *filename = 0;
-  int chunk_num = 0, global_chunk_size = 0, size = 0, pos = 0, fd = -1, safe = 0;
+  int chunk_num = 0, global_chunk_size = 0, size = 0, pos = 0, fd = -1;
 	int revert = 0;
   FILE *fp = 0;
 
   zval temp;
   zval *zid = 0, *zfile = 0, *chunks = 0;
-  zval **z_safe;
   zval *cleanup_ids;
 
   mongo_collection *c = (mongo_collection*)zend_object_store_get_object(getThis() TSRMLS_CC);
@@ -709,16 +727,6 @@ PHP_METHOD(MongoGridFS, storeFile) {
 		Z_ADDREF_P(options);
 	}
 
-	// force safe mode
-	if (zend_hash_find(Z_ARRVAL_P(options), "safe", strlen("safe")+1, (void**)&z_safe) == SUCCESS) {
-		convert_to_long_ex(z_safe);
-		if (Z_LVAL_PP(z_safe) < 1) {
-			add_assoc_long(options, "safe", 1);
-		}
-	} else {
-		add_assoc_long(options, "safe", 1);
-	}
-
 	MAKE_STD_ZVAL(cleanup_ids);
 	array_init(cleanup_ids);
 
@@ -765,7 +773,36 @@ PHP_METHOD(MongoGridFS, storeFile) {
 
     efree(buf);
 
-		if (safe && EG(exception)) {
+	/* Run GLE, just to ensure all the data has been written */
+	{
+		zval *data, *gle_retval;
+		MAKE_STD_ZVAL(data);
+		array_init(data);
+
+		add_assoc_long(data, "getlasterror", 1);
+
+		MAKE_STD_ZVAL(gle_retval);
+		ZVAL_NULL(gle_retval);
+
+		// run command
+		MONGO_CMD(gle_retval, c->parent);
+
+		if (Z_TYPE_P(gle_retval) == IS_ARRAY) {
+			zval **err;
+			if (zend_hash_find(Z_ARRVAL_P(gle_retval), "err", strlen("err")+1, (void**)&err) == SUCCESS && Z_TYPE_PP(err) == IS_STRING) {
+				zend_throw_exception_ex(mongo_ce_GridFSException, 0 TSRMLS_CC, Z_STRVAL_PP(err));
+				/* Intentionally not returning, the exception is checked a line later */
+			}
+		}
+		zval_ptr_dtor(&data);
+		zval_ptr_dtor(&gle_retval);
+		if (EG(exception)) {
+			revert = 1;
+			goto cleanup_on_failure;
+		}
+	}
+
+		if (EG(exception)) {
 			revert = 1;
 			goto cleanup_on_failure;
 		}

--- a/tests/generic/bug00320-2.phpt
+++ b/tests/generic/bug00320-2.phpt
@@ -5,7 +5,7 @@ Test for PHP-320: GridFS transaction issues with storeBytes(). (2)
 --FILE--
 <?php
 require_once dirname(__FILE__) ."/../utils.inc";
-$m = mongo("phpunit");
+$m = new_mongo("phpunit");
 	$mdb = $m->selectDB("phpunit");
 	$mdb->dropCollection("fs.files");
 	$mdb->dropCollection("fs.chunks");
@@ -19,10 +19,9 @@ $m = mongo("phpunit");
 	echo "######################################\n";
 	echo "# Saving files to GridFS\n";
 	echo "######################################\n";
-	$options = array( 'safe' => false );
 	for ($i = 0; $i < 3; $i++) {
 		try {
-			$new_saved_file_object_id = $GridFS->storeBytes($temporary_file_data, array( '_id' => "file{$i}", 'filename' => '/tmp/GridFS_test.txt'), $options);
+			$new_saved_file_object_id = $GridFS->storeBytes($temporary_file_data, array( '_id' => "file{$i}", 'filename' => '/tmp/GridFS_test.txt'));
 			echo "[Saved file] New file id:".$new_saved_file_object_id."\n";
 		}
 		catch (MongoException $e) {
@@ -31,7 +30,6 @@ $m = mongo("phpunit");
 		}
 
 	}
-	var_dump( $options );
 
 	echo "\n";
 	echo "######################################\n";
@@ -58,10 +56,6 @@ error message: Could not store file: %s:%d: E11000 duplicate key error index: ph
 error code: 11000
 error message: Could not store file: %s:%d: E11000 duplicate key error index: phpunit.fs.files.$filename_1  dup key: { : "/tmp/GridFS_test.txt" }
 error code: 11000
-array(1) {
-  ["safe"]=>
-  bool(false)
-}
 
 ######################################
 # Current documents in fs.files

--- a/tests/generic/bug00320.phpt
+++ b/tests/generic/bug00320.phpt
@@ -5,7 +5,7 @@ Test for PHP-320: GridFS transaction issues with storeFile().
 --FILE--
 <?php
 require_once dirname(__FILE__) . "/../utils.inc";
-$m = mongo("phpunit");
+$m = new_mongo("phpunit");
 	$mdb = $m->selectDB("phpunit");
 	$mdb->dropCollection("fs.files");
 	$mdb->dropCollection("fs.chunks");
@@ -21,7 +21,7 @@ $m = mongo("phpunit");
 	echo "######################################\n";
 	echo "# Saving files to GridFS\n";
 	echo "######################################\n";
-	$options = array( 'safe' => false );
+	$options = array( 'safe' => true );
 	for ($i = 0; $i < 3; $i++) {
 		try {
 			$new_saved_file_object_id = $GridFS->storeFile($temporary_file_name, array( '_id' => "file{$i}"), $options);
@@ -62,7 +62,7 @@ error message: Could not store file: %s:%d: E11000 duplicate key error index: ph
 error code: 11000
 array(1) {
   ["safe"]=>
-  bool(false)
+  bool(true)
 }
 
 ######################################

--- a/tests/generic/bug00372.phpt
+++ b/tests/generic/bug00372.phpt
@@ -19,7 +19,7 @@ PHP mongo driver: 1.3.0dev (16th Apr 2012)
 #Connect to GridFS
 require_once dirname(__FILE__) ."/../utils.inc";
 $db = 'phpunit';
-$m = mongo($db);
+$m = new_mongo($db);
 $prefix = 'test_prefix';
 $GridFS = $m->selectDB($db)->getGridFS($prefix);
 

--- a/tests/generic/bug00486.phpt
+++ b/tests/generic/bug00486.phpt
@@ -29,5 +29,5 @@ $gridfs->drop();
 ?>
 --EXPECTF--
 string(11) "./README.md"
-string(%d) "Could not store file: %s:%d: E11000 duplicate key error index: %s.fs.chunks.$files_id_1_n_1  dup key: { : 1, : 0 }"
+string(%d) "Could not store file:%sE11000 duplicate key error index: %s.fs.chunks.$files_id_1_n_1  dup key: { : 1, : 0 }"
 string(11) "./README.md"

--- a/tests/generic/bug00586.phpt
+++ b/tests/generic/bug00586.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Test for PHP-586: GridFS should only do one GLE
+--SKIPIF--
+<?php require dirname(__FILE__) . "/skipif.inc";?>
+--FILE--
+<?php
+require_once dirname(__FILE__) . "/../utils.inc";
+$mongo = mongo();
+$db = $mongo->selectDB(dbname());
+
+$gridfs = $db->getGridFS();
+$gridfs->drop();
+$gridfs->storeFile(__FILE__, array('x' => 1), array("w" => 1));
+
+$file = $gridfs->findOne(array(), array('x' => 1));
+
+try {
+    $file->getBytes();
+    var_dump(false);
+} catch (MongoGridFSException $e) {
+    var_dump(true);
+}
+--EXPECT--
+bool(true)

--- a/tests/generic/mongogridfs-storefile_error-002.phpt
+++ b/tests/generic/mongogridfs-storefile_error-002.phpt
@@ -19,4 +19,4 @@ try {
     echo $e->getMessage(), "\n";
 }
 --EXPECTF--
-Could not store file: %s:%d: E11000 duplicate key error index: %s.fs.chunks.$files_id_1_n_1  dup key: { : 1, : 0 }
+Could not store file:%sE11000 duplicate key error index: %s.fs.chunks.$files_id_1_n_1  dup key: { : 1, : 0 }

--- a/tests/replicaset/bug00586-replicaset.phpt
+++ b/tests/replicaset/bug00586-replicaset.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Test for PHP-586: GridFS should only do one GLE
+--SKIPIF--
+<?php require dirname(__FILE__) . "/skipif.inc";?>
+--FILE--
+<?php
+require_once dirname(__FILE__) . "/../utils.inc";
+$mongo = mongo();
+$db = $mongo->selectDB(dbname());
+
+$gridfs = $db->getGridFS();
+$gridfs->drop();
+$gridfs->storeFile(__FILE__, array('x' => 1), array("w" => 1));
+
+$file = $gridfs->findOne(array(), array('x' => 1));
+
+try {
+    $file->getBytes();
+    var_dump(false);
+} catch (MongoGridFSException $e) {
+    var_dump(true);
+}
+
+try {
+    /* FIXME: The timeout is broken and seems hardcoded. The actual timeout is irrelevant to this test, as long as it timesout the replication at all :) */
+    $gridfs->storeFile(__FILE__, array('x' => 1), array("w" => 42, "wtimeout" => 42));
+} catch(MongoGridFSException $e) {
+    var_dump($e->getMessage(), $e->getCode());
+}
+--EXPECTF--
+bool(true)
+string(%d) "Could not store file: %s:%d: timeout"
+int(4)


### PR DESCRIPTION
Removed this forced acknowledged behaviour so its now actually up to the
user what he wants to do.

We do however now execute one GLE at the end of writing all the chunks
to guarantee that we have written all the data before saving the
metadata and filemd5
