### PR TITLE
[PHP-680] Reset tag count after freeing tagsets

### DIFF
--- a/mcon/read_preference.c
+++ b/mcon/read_preference.c
@@ -566,6 +566,7 @@ void mongo_read_preference_dtor(mongo_read_preference *rp)
 	for (i = 0; i < rp->tagset_count; i++) {
 		mongo_read_preference_tagset_dtor(rp->tagsets[i]);
 	}
+	rp->tagset_count = 0;
 	free(rp->tagsets);
 	/* We are not freeing *rp itself, as that's not always a pointer */
 }

--- a/tests/generic/bug00680.phpt
+++ b/tests/generic/bug00680.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test for PHP-680: mongo_read_preference_dtor() will segfault if invoked twice
+--SKIPIF--
+<?php require_once dirname(__FILE__) ."/skipif.inc"; ?>
+--FILE--
+<?php require_once dirname(__FILE__) . "/../utils.inc"; ?>
+<?php
+
+$m = new_mongo();
+var_dump($m->setReadPreference(Mongo::RP_PRIMARY_PREFERRED, array(array('dc' => 'east'))));
+var_dump($m->setReadPreference(Mongo::RP_PRIMARY_PREFERRED, array('not_an_array')));
+
+?>
+--EXPECTF--
+bool(true)
+
+Warning: MongoClient::setReadPreference(): Tagset 1 needs to contain an array of 0 or more tags in %s on line %d
+bool(false)


### PR DESCRIPTION
See: https://jira.mongodb.org/browse/PHP-680
