### PR TITLE
Fixed PHP-650: Segmentation fault when using findAndModify().

### DIFF
--- a/collection.c
+++ b/collection.c
@@ -1803,6 +1803,11 @@ static int php_mongo_trigger_error_on_command_failure(zval *document TSRMLS_DC)
 {
 	zval **tmpvalue;
 
+	if (Z_TYPE_P(document) != IS_ARRAY) {
+		zend_throw_exception(mongo_ce_ResultException, strdup("Unknown error executing command (empty document returned)"), 0 TSRMLS_CC);
+		return FAILURE;
+	}
+
 	if (zend_hash_find(Z_ARRVAL_P(document), "ok", strlen("ok") + 1, (void **) &tmpvalue) == SUCCESS) {
 		if ((Z_TYPE_PP(tmpvalue) == IS_LONG && Z_LVAL_PP(tmpvalue) < 1) || (Z_TYPE_PP(tmpvalue) == IS_DOUBLE && Z_DVAL_PP(tmpvalue) < 1)) {
 			zval **tmp, *exception;


### PR DESCRIPTION
In some cases, where findAndModify() causes a cursor (or other timeout), the
returned document is NULL. Because we didn't check for this, a segfault
occured.

Writing a test case for this is tricky as we'd need to simulate a failure.
