### PR TITLE
Fixed PHP-685: wtimeout option is not supported per-query

### DIFF
--- a/tests/replicaset/bug00685.phpt
+++ b/tests/replicaset/bug00685.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Test for PHP-685: wtimeout option is not supported per-query
+--SKIPIF--
+<?php require_once dirname(__FILE__) . "/skipif.inc" ?>
+--FILE--
+<?php
+require_once dirname(__FILE__) . "/../utils.inc";
+
+$m = new_mongo();
+
+try {
+    /* Noway you can replicate to 2 server so fast :D */
+    $m->selectDb(dbname())->test->insert(array("random" => "data"), array("wtimeout" => 1, "w" => 2));
+} catch(MongoCursorException $e) {
+    var_dump($e->getMessage(), $e->getCode());
+}
+
+?>
+--EXPECTF--
+string(%s) "%s:%d: timeout"
+int(4)


### PR DESCRIPTION
We simply never checked for the option in the options array.
Now we'll fall back on the MongoCollection->wtimeout (which inherits the
wtimeout from MongoDB->wtimeout, which is set by the connection string,
or defaults to PHP_MONGO_DEFAULT_WTIMEOUT)
