### PR TITLE
Fixed PHP-690: Percentage symbol is not escaped in error messages

### DIFF
--- a/collection.c
+++ b/collection.c
@@ -556,7 +556,7 @@ static void do_safe_op(mongo_con_manager *manager, mongo_connection *connection,
 		/* TODO: Figure out what to do on FAIL
 		mongo_util_link_failed(cursor->link, server TSRMLS_CC); */
 		mongo_manager_log(manager, MLOG_IO, MLOG_WARN, "do_safe_op: sending data failed, removing connection %s", connection->hash);
-		mongo_cursor_throw(connection, 16 TSRMLS_CC, error_message);
+		mongo_cursor_throw(connection, 16 TSRMLS_CC, "%s", error_message);
 		connection_deregister_wrapper(manager, connection TSRMLS_CC);
 
 		free(error_message);    
@@ -596,7 +596,7 @@ static void do_safe_op(mongo_con_manager *manager, mongo_connection *connection,
     zval **code;
     int status = zend_hash_find(Z_ARRVAL_P(return_value), "n", strlen("n")+1, (void**)&code);
 
-		mongo_cursor_throw(cursor->connection, (status == SUCCESS ? Z_LVAL_PP(code) : 0) TSRMLS_CC, Z_STRVAL_PP(err));
+		mongo_cursor_throw(cursor->connection, (status == SUCCESS ? Z_LVAL_PP(code) : 0) TSRMLS_CC, "%s", Z_STRVAL_PP(err));
 
     cursor->connection = NULL;
     zval_ptr_dtor(&cursor_z);

--- a/cursor.c
+++ b/cursor.c
@@ -190,7 +190,7 @@ int php_mongo_get_reply(mongo_cursor *cursor, zval *errmsg TSRMLS_DC)
 
 	status = get_cursor_header(sock, cursor, (char**) &error_message TSRMLS_CC);
 	if (status == -1 || status > 0) {
-		mongo_cursor_throw(cursor->connection, status TSRMLS_CC, error_message);
+		mongo_cursor_throw(cursor->connection, status TSRMLS_CC, "%s", error_message);
 		free(error_message);
 		return FAILURE;
 	}
@@ -400,7 +400,7 @@ PHP_METHOD(MongoCursor, hasNext) {
 	if (mongo_io_send(cursor->connection->socket, buf.start, buf.pos - buf.start, (char**) &error_message) == -1) {
 		efree(buf.start);
 
-		mongo_cursor_throw(cursor->connection, 1 TSRMLS_CC, error_message);
+		mongo_cursor_throw(cursor->connection, 1 TSRMLS_CC, "%s", error_message);
 		free(error_message);
 		mongo_util_cursor_failed(cursor TSRMLS_CC);
 		return;
@@ -1242,7 +1242,7 @@ PHP_METHOD(MongoCursor, next) {
 				snprintf(error_message, Z_STRLEN_PP(err) + 2 + Z_STRLEN_PP(wnote) + 1, "%s: %s", Z_STRVAL_PP(err), Z_STRVAL_PP(wnote));
 			}
 
-      exception = mongo_cursor_throw(cursor->connection, code TSRMLS_CC, error_message);
+      exception = mongo_cursor_throw(cursor->connection, code TSRMLS_CC, "%s", error_message);
 			free(error_message);
       zend_update_property(mongo_ce_CursorException, exception, "doc", strlen("doc"), cursor->current TSRMLS_CC);
       zval_ptr_dtor(&cursor->current);

--- a/tests/generic/bug00690.phpt
+++ b/tests/generic/bug00690.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Test for PHP-690: Percentage symbol is not escaped in error messages
+--SKIPIF--
+<?php require_once dirname(__FILE__) . '/skipif.inc'; ?>
+--FILE--
+<?php require_once dirname(__FILE__) . '/../utils.inc'; ?>
+<?php
+$m = new_mongo();
+$c = $m->selectCollection(dbname(), 'bug690');
+$c->drop();
+
+$c->insert(array('_id'=>'hello%20London', 'added'=>time()));
+try
+{
+	$c->insert(array('_id'=>'hello%20London', 'added'=>time()));
+}
+catch ( Exception $e )
+{
+	echo $e->getMessage(), "\n";
+}
+
+?>
+--EXPECTF--
+%s:%d: E11000 duplicate key error index: %s dup key: { : "hello%20London" }


### PR DESCRIPTION
We need to use "%s", error_message when passing to the varargs function
mongo_cursor_throw. The explanation for why this is important is well described
at http://en.wikipedia.org/wiki/Uncontrolled_format_string
