### PR TITLE
Fixes PHP-680: Always free tagset in dtor function

### DIFF
--- a/mcon/read_preference.c
+++ b/mcon/read_preference.c
@@ -561,15 +561,15 @@ void mongo_read_preference_tagset_dtor(mongo_read_preference_tagset *tagset)
 {
 	int i;
 
-	if (tagset->tag_count == 0) {
-		return;
+	if (tagset->tag_count > 0) {
+		for (i = 0; i < tagset->tag_count; i++) {
+			free(tagset->tags[i]);
+		}
+
+		tagset->tag_count = 0;
+		free(tagset->tags);
 	}
 
-	for (i = 0; i < tagset->tag_count; i++) {
-		free(tagset->tags[i]);
-	}
-	tagset->tag_count = 0;
-	free(tagset->tags);
 	free(tagset);
 }
 


### PR DESCRIPTION
See: https://jira.mongodb.org/browse/PHP-680?focusedCommentId=253631&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-253631

Previously, tagset would not be freed if it contained no tags. Since it is always allocated, we should free it regardless of whether tags were added to it.
