### PR TITLE
Fixed PHP-691: Memory leak during master failover

### DIFF
--- a/collection.c
+++ b/collection.c
@@ -642,6 +642,7 @@ PHP_METHOD(MongoCollection, insert) {
   PHP_MONGO_GET_COLLECTION(getThis());
 
 	if ((connection = get_server(c, MONGO_CON_FLAG_WRITE TSRMLS_CC)) == 0) {
+		zval_ptr_dtor(&options);
 		RETURN_FALSE;
 	}
 


### PR DESCRIPTION
MongoCollection->update() & remove() do not have this problem
