### PR TITLE
Removed old API checks and some unused code.

### DIFF
--- a/bson.c
+++ b/bson.c
@@ -44,11 +44,11 @@ ZEND_EXTERN_MODULE_GLOBALS(mongo);
 
 static int get_limit(mongo_cursor *cursor);
 static int prep_obj_for_db(buffer *buf, HashTable *array TSRMLS_DC);
-#if ZEND_MODULE_API_NO >= 20090115
+#if PHP_VERSION_ID >= 50300
 static int apply_func_args_wrapper(void **data TSRMLS_DC, int num_args, va_list args, zend_hash_key *key);
 #else
 static int apply_func_args_wrapper(void **data, int num_args, va_list args, zend_hash_key *key);
-#endif /* ZEND_MODULE_API_NO >= 20090115 */
+#endif
 static int is_utf8(const char *s, int len);
 static int insert_helper(buffer *buf, zval *doc, int max TSRMLS_DC);
 
@@ -104,7 +104,7 @@ int zval_to_bson(buffer *buf, HashTable *hash, int prep TSRMLS_DC)
 			num++;
 		}
 
-#if ZEND_MODULE_API_NO >= 20090115
+#if PHP_VERSION_ID >= 50300
 		zend_hash_apply_with_arguments(hash TSRMLS_CC, (apply_func_args_t)apply_func_args_wrapper, 3, buf, prep, &num);
 #else
 		zend_hash_apply_with_arguments(hash, (apply_func_args_t)apply_func_args_wrapper, 4, buf, prep, &num TSRMLS_CC);
@@ -116,7 +116,7 @@ int zval_to_bson(buffer *buf, HashTable *hash, int prep TSRMLS_DC)
 	return EG(exception) ? FAILURE : num;
 }
 
-#if ZEND_MODULE_API_NO >= 20090115
+#if PHP_VERSION_ID >= 50300
 static int apply_func_args_wrapper(void **data TSRMLS_DC, int num_args, va_list args, zend_hash_key *key)
 #else
 static int apply_func_args_wrapper(void **data, int num_args, va_list args, zend_hash_key *key)
@@ -125,7 +125,7 @@ static int apply_func_args_wrapper(void **data, int num_args, va_list args, zend
 	buffer *buf = va_arg(args, buffer*);
 	int prep = va_arg(args, int);
 	int *num = va_arg(args, int*);
-#if ZEND_MODULE_API_NO < 20090115
+#if ZTS && PHP_VERSION_ID < 50300
 	void ***tsrm_ls = va_arg(args, void***);
 #endif
 
@@ -1373,12 +1373,8 @@ PHP_FUNCTION(bson_encode)
 		}
 
 		default:
-#if ZEND_MODULE_API_NO >= 20060613
-		zend_throw_exception(zend_exception_get_default(TSRMLS_C), "couldn't serialize element", 0 TSRMLS_CC);
-#else
-		zend_throw_exception(zend_exception_get_default(), "couldn't serialize element", 0 TSRMLS_CC);
-#endif
-		return;
+			zend_throw_exception(zend_exception_get_default(TSRMLS_C), "couldn't serialize element", 0 TSRMLS_CC);
+			return;
 	}
 }
 

--- a/collection.c
+++ b/collection.c
@@ -59,11 +59,7 @@ PHP_METHOD(MongoCollection, __construct)
 
 	/* check for empty collection name */
 	if (name_len == 0) {
-#if ZEND_MODULE_API_NO >= 20060613
 		zend_throw_exception_ex(zend_exception_get_default(TSRMLS_C), 0 TSRMLS_CC, "MongoDB::__construct(): invalid name %s", name_str);
-#else
-		zend_throw_exception_ex(zend_exception_get_default(), 0 TSRMLS_CC, "MongoDB::__construct(): invalid name %s", name_str);
-#endif
 		return;
 	}
 

--- a/cursor.c
+++ b/cursor.c
@@ -1109,11 +1109,7 @@ PHP_METHOD(MongoCursor, key)
 
 	if (cursor->current && Z_TYPE_P(cursor->current) == IS_ARRAY && zend_hash_find(HASH_P(cursor->current), "_id", 4, (void**)&id) == SUCCESS) {
 		if (Z_TYPE_PP(id) == IS_OBJECT) {
-#if ZEND_MODULE_API_NO >= 20060613
 			zend_std_cast_object_tostring(*id, return_value, IS_STRING TSRMLS_CC);
-#else
-			zend_std_cast_object_tostring(*id, return_value, IS_STRING, 0 TSRMLS_CC);
-#endif
 		} else {
 			RETVAL_ZVAL(*id, 1, 0);
 			convert_to_string(return_value);

--- a/db.c
+++ b/db.c
@@ -71,11 +71,7 @@ PHP_METHOD(MongoDB, __construct)
 		strchr(name, ' ') != 0 || strchr(name, '.') != 0 || strchr(name, '\\') != 0 ||
 		strchr(name, '/') != 0 || strchr(name, '$') != 0
 	) {
-#if ZEND_MODULE_API_NO >= 20060613
 		zend_throw_exception_ex(zend_exception_get_default(TSRMLS_C), 0 TSRMLS_CC, "MongoDB::__construct(): invalid name %s", name);
-#else
-		zend_throw_exception_ex(zend_exception_get_default(), 0 TSRMLS_CC, "MongoDB::__construct(): invalid name %s", name);
-#endif
 		return;
 	}
 

--- a/gridfs.c
+++ b/gridfs.c
@@ -106,11 +106,7 @@ PHP_METHOD(MongoGridFS, __construct)
 		char *temp;
 
 		if (Z_TYPE_P(files) != IS_STRING || Z_STRLEN_P(files) == 0 ) {
-#if ZEND_MODULE_API_NO >= 20060613
 			zend_throw_exception_ex(zend_exception_get_default(TSRMLS_C), 2 TSRMLS_CC, "MongoGridFS::__construct(): invalid prefix");
-#else
-			zend_throw_exception_ex(zend_exception_get_default(), 2 TSRMLS_CC, "MongoGridFS::__construct(): invalid prefix");
-#endif
 			return;
 		}
 
@@ -700,11 +696,7 @@ PHP_METHOD(MongoGridFS, storeFile)
 	} else {
 		char *msg = "first argument must be a string or stream resource";
 
-#if ZEND_MODULE_API_NO >= 20060613
 		zend_throw_exception(zend_exception_get_default(TSRMLS_C), msg, 8 TSRMLS_CC);
-#else
-		zend_throw_exception(zend_exception_get_default(), msg, 8 TSRMLS_CC);
-#endif
 		return;
 	}
 

--- a/php_mongo.c
+++ b/php_mongo.c
@@ -67,9 +67,7 @@ zend_function_entry mongo_functions[] = {
 /* {{{ mongo_module_entry
  */
 zend_module_entry mongo_module_entry = {
-#if ZEND_MODULE_API_NO >= 20010901
 	STANDARD_MODULE_HEADER,
-#endif
 	PHP_MONGO_EXTNAME,
 	mongo_functions,
 	PHP_MINIT(mongo),
@@ -78,15 +76,11 @@ zend_module_entry mongo_module_entry = {
 	NULL,
 	PHP_MINFO(mongo),
 	PHP_MONGO_VERSION,
-#if ZEND_MODULE_API_NO >= 20060613
 	PHP_MODULE_GLOBALS(mongo),
 	PHP_GINIT(mongo),
 	PHP_GSHUTDOWN(mongo),
 	NULL,
 	STANDARD_MODULE_PROPERTIES_EX
-#else
-	STANDARD_MODULE_PROPERTIES
-#endif
 };
 /* }}} */
 
@@ -140,10 +134,6 @@ PHP_INI_END()
 PHP_MINIT_FUNCTION(mongo)
 {
 	zend_class_entry max_key, min_key;
-
-#if ZEND_MODULE_API_NO < 20060613
-	ZEND_INIT_MODULE_GLOBALS(mongo, mongo_init_globals, NULL);
-#endif
 
 	REGISTER_INI_ENTRIES();
 	le_cursor_list = zend_register_list_destructors_ex(NULL, php_mongo_cursor_list_pfree, PHP_CURSOR_LIST_RES_NAME, module_number);
@@ -342,11 +332,7 @@ static void mongo_init_MongoExceptions(TSRMLS_D)
 
 	INIT_CLASS_ENTRY(e, "MongoException", NULL);
 
-#if ZEND_MODULE_API_NO >= 20060613
 	mongo_ce_Exception = zend_register_internal_class_ex(&e, (zend_class_entry*)zend_exception_get_default(TSRMLS_C), NULL TSRMLS_CC);
-#else
-	mongo_ce_Exception = zend_register_internal_class_ex(&e, (zend_class_entry*)zend_exception_get_default(), NULL TSRMLS_CC);
-#endif
 
 	mongo_init_CursorExceptions(TSRMLS_C);
 

--- a/php_mongo.h
+++ b/php_mongo.h
@@ -136,7 +136,7 @@ typedef __int64 int64_t;
 # define MONGO_ARGINFO_STATIC static
 #endif
 
-#if ZEND_MODULE_API_NO >= 20090115
+#if PHP_VERSION_ID >= 50300
 # define PUSH_PARAM(arg) zend_vm_stack_push(arg TSRMLS_CC)
 # define POP_PARAM() (void)zend_vm_stack_pop(TSRMLS_C)
 # define PUSH_EO_PARAM()
@@ -148,7 +148,7 @@ typedef __int64 int64_t;
 # define POP_EO_PARAM() (void)zend_ptr_stack_pop(&EG(argument_stack))
 #endif
 
-#if ZEND_MODULE_API_NO > 20060613
+#if PHP_VERSION_ID >= 50300
 # define MONGO_E_DEPRECATED E_DEPRECATED
 #else
 # define MONGO_E_DEPRECATED E_STRICT
@@ -181,13 +181,7 @@ typedef __int64 int64_t;
 } while(0);
 #endif
 
-#if ZEND_MODULE_API_NO >= 20060613
-/* normal, nice method */
-# define MONGO_METHOD_BASE(classname, name) zim_##classname##_##name
-#else
-/* gah!  wtf, php 5.1? */
-# define MONGO_METHOD_BASE(classname, name) zif_##classname##_##name
-#endif
+#define MONGO_METHOD_BASE(classname, name) zim_##classname##_##name
 
 #define MONGO_METHOD_HELPER(classname, name, retval, thisptr, num, param) \
 	PUSH_PARAM(param); PUSH_PARAM((void*)num);				\
@@ -239,7 +233,7 @@ typedef __int64 int64_t;
   ((Z_TYPE_PP(variable) == IS_LONG && Z_LVAL_PP(variable) == value) ||  \
    (Z_TYPE_PP(variable) == IS_DOUBLE && Z_DVAL_PP(variable) == value))
 
-#if ZEND_MODULE_API_NO >= 20100525
+#if PHP_VERSION_ID >= 50400
 # define init_properties(intern) object_properties_init(&intern->std, class_type)
 #else
 # define init_properties(intern) {                                     \


### PR DESCRIPTION
We could remove some code as we don't support PHP 5.1 anymore.  I've tested to
build with 5.2.18, 5.3.22, 5.4.12 and 5.5.0 in both ZTS and normal builds at
64bit, as well as 5.3.20 and 5.4.9 in 32bit (no-ZTS).
