### PR TITLE
Fixed PHP-704: Incorrect failure checks for stream reads

### DIFF
--- a/cursor.c
+++ b/cursor.c
@@ -201,12 +201,13 @@ int php_mongo_get_reply(mongo_cursor *cursor, zval *errmsg TSRMLS_DC)
 		return FAILURE;
 	}
 
-	if (FAILURE == get_cursor_body(sock, cursor, (char **) &error_message TSRMLS_CC)) {
+	if (0 == get_cursor_body(sock, cursor, (char **) &error_message TSRMLS_CC)) {
 #ifdef WIN32
 		mongo_cursor_throw(cursor->connection, 12 TSRMLS_CC, "WSA error getting database response %s (%d)", error_message, WSAGetLastError());
 #else
 		mongo_cursor_throw(cursor->connection, 12 TSRMLS_CC, "error getting database response %s (%d)", error_message, strerror(errno));
 #endif
+		free(error_message);
 		return FAILURE;
 	}
 


### PR DESCRIPTION
get_cursor_body() returns 0 on failure. I reviewed all other instances
of similar calls and they all look fine.
On failure, we also need to free the error message after throwing the
exception
