### PR TITLE
Fixed PHP-665: Add support for Auth Specification

### DIFF
--- a/db.c
+++ b/db.c
@@ -769,6 +769,7 @@ PHP_METHOD(MongoDB, authenticate)
 	/* Update all the servers */
 	for (i = 0; i < link->servers->count; i++) {
 		link->servers->server[i]->db = strdup(Z_STRVAL_P(db->name));
+		link->servers->server[i]->authdb = strdup(Z_STRVAL_P(db->name));
 		link->servers->server[i]->username = strdup(username);
 		link->servers->server[i]->password = strdup(password);
 	}
@@ -786,6 +787,8 @@ PHP_METHOD(MongoDB, authenticate)
 		for (i = 0; i < link->servers->count; i++) {
 			free(link->servers->server[i]->db);
 			link->servers->server[i]->db = NULL;
+			free(link->servers->server[i]->authdb);
+			link->servers->server[i]->authdb = NULL;
 			free(link->servers->server[i]->username);
 			link->servers->server[i]->username = NULL;
 			free(link->servers->server[i]->password);

--- a/mcon/manager.c
+++ b/mcon/manager.c
@@ -63,7 +63,7 @@ static mongo_connection *mongo_get_connection_single(mongo_con_manager *manager,
 			/* Do authentication if requested */
 			if (server->db && server->username && server->password) {
 				mongo_manager_log(manager, MLOG_CON, MLOG_INFO, "get_connection_single: authenticating %s", hash);
-				if (!authenticate_connection(manager, con, options, server->db, server->username, server->password, error_message)) {
+				if (!authenticate_connection(manager, con, options, server->authdb ? server->authdb : server->db, server->username, server->password, error_message)) {
 					mongo_connection_destroy(manager, con);
 					con = NULL;
 					goto bailout;
@@ -153,6 +153,7 @@ static void mongo_discover_topology(mongo_con_manager *manager, mongo_servers *s
 					tmp_def->password = servers->server[i]->password ? strdup(servers->server[i]->password) : NULL;
 					tmp_def->repl_set_name = servers->server[i]->repl_set_name ? strdup(servers->server[i]->repl_set_name) : NULL;
 					tmp_def->db = servers->server[i]->db ? strdup(servers->server[i]->db) : NULL;
+					tmp_def->authdb = servers->server[i]->authdb ? strdup(servers->server[i]->authdb) : NULL;
 					tmp_def->host = mcon_strndup(found_hosts[j], strchr(found_hosts[j], ':') - found_hosts[j]);
 					tmp_def->port = atoi(strchr(found_hosts[j], ':') + 1);
 					

--- a/mcon/parse.c
+++ b/mcon/parse.c
@@ -227,7 +227,8 @@ void static mongo_add_parsed_server_addr(mongo_con_manager *manager, mongo_serve
 
 	tmp = malloc(sizeof(mongo_server_def));
 	memset(tmp, 0, sizeof(mongo_server_def));
-	tmp->username = tmp->password = tmp->db = NULL;
+	tmp->username = tmp->password = tmp->db = tmp->authdb = NULL;
+	tmp->mechanism = MONGO_AUTH_MECHANISM_MONGODB_CR; /* MONGODB-CR is the default authentication mechanism */
 	tmp->port = 27017;
 
 	tmp->host = mcon_strndup(host_start, host_end - host_start);
@@ -362,6 +363,8 @@ int mongo_store_option(mongo_con_manager *manager, mongo_servers *servers, char 
 			 * value before setting it anyway. */
 			if (!servers->server[i]->db) {
 				servers->server[i]->db = strdup("admin");
+				/* Admin users always authenticate on the admin db, even when using other databases */
+				servers->server[i]->authdb = strdup("admin");
 			}
 		}
 		return 0;
@@ -381,11 +384,50 @@ int mongo_store_option(mongo_con_manager *manager, mongo_servers *servers, char 
 		for (i = 0; i < servers->count; i++) {
 			if (servers->server[i]->db) {
 				free(servers->server[i]->db);
+				/* Free the authdb too as it defaulted to 'admin' when no db was passed as the connection string */
+				free(servers->server[i]->authdb);
+				servers->server[i]->authdb = NULL;
 			}
 			servers->server[i]->db = strdup(option_value);
 		}
 		return 0;
 	}
+	if (strcasecmp(option_name, "authSource") == 0) {
+		mongo_manager_log(manager, MLOG_PARSE, MLOG_INFO, "- Found option 'authSource': '%s'", option_value);
+		for (i = 0; i < servers->count; i++) {
+			if (servers->server[i]->authdb) {
+				free(servers->server[i]->authdb);
+			}
+			servers->server[i]->authdb = strdup(option_value);
+		}
+		return 0;
+	}
+	if (strcasecmp(option_name, "authMechanism") == 0) {
+		int mechanism;
+
+		mongo_manager_log(manager, MLOG_PARSE, MLOG_INFO, "- Found option 'authMechanism': '%s'", option_value);
+		if (strcasecmp(option_value, "MONGODB-CR") == 0) {
+			mechanism = MONGO_AUTH_MECHANISM_MONGODB_CR;
+		}
+		else if (strcasecmp(option_value, "GSSAPI") == 0) {
+			/* FIXME: GSSAPI isn't implemented yet */
+			mechanism = MONGO_AUTH_MECHANISM_GSSAPI;
+			*error_message = strdup("GSSAPI authMechanism is currently not supported");
+			return 3;
+		}
+		else {
+			int len = strlen(option_value) + sizeof("Unknown authMechanism '%s'. Currently only MONGODB-CR is supported");
+
+			*error_message = malloc(len + 1);
+			snprintf(*error_message, len, "Unknown authMechanism '%s'. Currently only MONGODB-CR is supported", option_value);
+			return 3;
+		}
+		for (i = 0; i < servers->count; i++) {
+			servers->server[i]->mechanism = mechanism;
+		}
+		return 0;
+	}
+
 	if (strcasecmp(option_name, "slaveOkay") == 0) {
 		if (strcasecmp(option_value, "true") == 0 || *option_value == '1') {
 			mongo_manager_log(manager, MLOG_PARSE, MLOG_INFO, "- Found option 'slaveOkay': true");
@@ -539,8 +581,8 @@ int static mongo_parse_options(mongo_con_manager *manager, mongo_servers *server
 void static mongo_server_def_dump(mongo_con_manager *manager, mongo_server_def *server_def)
 {
 	mongo_manager_log(manager, MLOG_PARSE, MLOG_INFO,
-		"- host: %s; port: %d; username: %s, password: %s, database: %s",
-		server_def->host, server_def->port, server_def->username, server_def->password, server_def->db);
+		"- host: %s; port: %d; username: %s, password: %s, database: %s, auth source: %s, mechanism: %d",
+		server_def->host, server_def->port, server_def->username, server_def->password, server_def->db, server_def->authdb, server_def->mechanism);
 }
 
 void mongo_servers_dump(mongo_con_manager *manager, mongo_servers *servers)
@@ -567,7 +609,8 @@ void mongo_servers_dump(mongo_con_manager *manager, mongo_servers *servers)
 /* Cloning */
 static void mongo_server_def_copy(mongo_server_def *to, mongo_server_def *from, int flags)
 {
-	to->host = to->repl_set_name = to->db = to->username = to->password = NULL;
+	to->host = to->repl_set_name = to->db = to->authdb = to->username = to->password = NULL;
+	to->mechanism = MONGO_AUTH_MECHANISM_MONGODB_CR;
 	if (from->host) {
 		to->host = strdup(from->host);
 	}
@@ -580,12 +623,16 @@ static void mongo_server_def_copy(mongo_server_def *to, mongo_server_def *from, 
 		if (from->db) {
 			to->db = strdup(from->db);
 		}
+		if (from->authdb) {
+			to->authdb = strdup(from->authdb);
+		}
 		if (from->username) {
 			to->username = strdup(from->username);
 		}
 		if (from->password) {
 			to->password = strdup(from->password);
 		}
+		to->mechanism = from->mechanism;
 	}
 }
 
@@ -627,6 +674,9 @@ void mongo_server_def_dtor(mongo_server_def *server_def)
 	}
 	if (server_def->db) {
 		free(server_def->db);
+	}
+	if (server_def->authdb) {
+		free(server_def->authdb);
 	}
 	if (server_def->username) {
 		free(server_def->username);

--- a/mcon/types.h
+++ b/mcon/types.h
@@ -160,14 +160,19 @@ typedef struct _mongo_read_preference
 	mongo_read_preference_tagset **tagsets;
 } mongo_read_preference;
 
+#define MONGO_AUTH_MECHANISM_MONGODB_CR 1
+#define MONGO_AUTH_MECHANISM_GSSAPI     2
+
 typedef struct _mongo_server_def
 {
 	char *host;
 	int   port;
 	char *repl_set_name;
 	char *db;
+	char *authdb;
 	char *username;
 	char *password;
+	int   mechanism;
 } mongo_server_def;
 
 /* NOTE: when making changes, update mongo_parse_init, mongo_servers_copy and mongo_servers_dtor */

--- a/mongoclient.c
+++ b/mongoclient.c
@@ -579,6 +579,7 @@ PHP_METHOD(MongoClient, selectDB)
 	char *db;
 	int db_len;
 	mongoclient *link;
+	int free_this_ptr = 0;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &db, &db_len) == FAILURE) {
 		return;
@@ -605,6 +606,7 @@ PHP_METHOD(MongoClient, selectDB)
 		if (link->servers->server[0]->username && link->servers->server[0]->password) {
 			zval       *new_link;
 			mongoclient *tmp_link;
+			int i;
 		
 			if (strcmp(link->servers->server[0]->db, "admin") == 0) {
 				mongo_manager_log(
@@ -625,9 +627,14 @@ PHP_METHOD(MongoClient, selectDB)
 
 				tmp_link->manager = link->manager;
 				tmp_link->servers = calloc(1, sizeof(mongo_servers));
-				mongo_servers_copy(tmp_link->servers, link->servers, MONGO_SERVER_COPY_NONE);
+				mongo_servers_copy(tmp_link->servers, link->servers, MONGO_SERVER_COPY_CREDENTIALS);
+				/* We assume the previous credentials will work on this database too, or if authSource is set, authenticate against that db */
+				for (i = 0; i < tmp_link->servers->count; i++) {
+					tmp_link->servers->server[i]->db = strdup(db);
+				}
 
 				this_ptr = new_link;
+				free_this_ptr = 1;
 			}
 		}
 	}
@@ -636,6 +643,9 @@ PHP_METHOD(MongoClient, selectDB)
 	MONGO_METHOD2(MongoDB, __construct, &temp, return_value, getThis(), name);
 
 	zval_ptr_dtor(&name);
+	if (free_this_ptr) {
+		zval_ptr_dtor(&this_ptr);
+	}
 }
 /* }}} */
 


### PR DESCRIPTION
Implemented support for surrogate users, defined in a seperate database
then currently using.

Also fixed a memory leak when switching between databases with
credentials.

Added support for the authSource connection string option, as well as
future compatability support for authMechanism.
