### PR TITLE
Fix bad fix for PHP-704

### DIFF
--- a/cursor.c
+++ b/cursor.c
@@ -158,7 +158,7 @@ static signed int get_cursor_header(int sock, mongo_cursor *cursor, char **error
 }
 
 /* Reads a cursors body
- * Returns 0 on failure or an int indicating the number of bytes read */
+ * Returns -1 on failure or an int indicating the number of bytes read */
 static int get_cursor_body(int sock, mongo_cursor *cursor, char **error_message TSRMLS_DC)
 {
 	mongoclient *client = (mongoclient*)zend_object_store_get_object(cursor->resource TSRMLS_CC);
@@ -201,7 +201,7 @@ int php_mongo_get_reply(mongo_cursor *cursor, zval *errmsg TSRMLS_DC)
 		return FAILURE;
 	}
 
-	if (0 == get_cursor_body(sock, cursor, (char **) &error_message TSRMLS_CC)) {
+	if (get_cursor_body(sock, cursor, (char **) &error_message TSRMLS_CC) == FAILURE) {
 #ifdef WIN32
 		mongo_cursor_throw(cursor->connection, 12 TSRMLS_CC, "WSA error getting database response %s (%d)", error_message, WSAGetLastError());
 #else

--- a/mcon/connections.c
+++ b/mcon/connections.c
@@ -362,7 +362,7 @@ static int mongo_connect_send_packet(mongo_con_manager *manager, mongo_connectio
 
 	/* Read data */
 	*data_buffer = malloc(data_size + 1);
-	if (!mongo_io_recv_data(con->socket, options, *data_buffer, data_size, error_message)) {
+	if (mongo_io_recv_data(con->socket, options, *data_buffer, data_size, error_message) <= 0) {
 		return 0;
 	}
 

--- a/mcon/io.c
+++ b/mcon/io.c
@@ -160,13 +160,13 @@ int mongo_io_recv_data(int sock, mongo_server_options *options, void *dest, int 
 
 		if (mongo_io_wait_with_timeout(sock, options->socketTimeoutMS, error_message) != 0) {
 			/* We don't care which failure it was, it just failed */
-			return 0;
+			return -1;
 		}
 		// windows gives a WSAEFAULT if you try to get more bytes
 		num = recv(sock, (char*)dest, len, 0);
 
 		if (num < 0) {
-			return 0;
+			return -1;
 		}
 
 		dest = (char*)dest + num;


### PR DESCRIPTION
mongod will return empty data (0) when there simply aren't any results,
so we cannot use 0 for a failure condition.
An empty response it totall valid, as it means the query criteria simply
didn't get any results
