### PR TITLE
The getBytes  method may return random data in particular conditions.

### DIFF
--- a/gridfs/gridfs_file.c
+++ b/gridfs/gridfs_file.c
@@ -262,7 +262,7 @@ PHP_METHOD(MongoGridFSFile, getBytes)
 		return;
 	}
 
-	str = (char *)ecalloc(len + 1, sizeof(char *));
+	str = (char *)ecalloc(len + 1, 1);
 	str_ptr = str;
 
 	if (apply_to_cursor(cursor, copy_bytes, &str, len + 1 TSRMLS_CC) == FAILURE) {


### PR DESCRIPTION
If the chunk data lost in the server(or not saved properly), leaving only the metadata, the getData method would return random data.

Reproduce data:

```
> db.fs.files.findOne({fileName:'test.txt'});                  
{
    "_id" : ObjectId("51417e1df85ac56f1200023c"),
    "fileName" : "test.txt",
    "owner" : "kmj3njwojk",
    "permission" : {
        "other" : {
            "read" : 1,
            "write" : 0
        },
        "group" : {
            "read" : 1,
            "write" : 0
        },
        "unreg" : {
            "read" : 1,
            "write" : 0
        },
        "deny" : {
            "read" : 0,
            "write" : 0
        }
    },
    "tag" : [ ],
    "path" : {
        "fn" : "test.txt"
    },
    "filename" : "/tmpfs/phpXAPPjB",
    "uploadDate" : ISODate("2013-03-14T07:37:01.951Z"),
    "length" : 9633,
    "chunkSize" : 262144,
    "md5" : "d41d8cd98f00b204e9800998ecf8427e"
}
> db.fs.chunks.find({files_id: ObjectId("51417e1df85ac56f1200023c")});
>
```
