### PR TITLE
Fixed CID-11031: Dereference after null check

### DIFF
--- a/cursor.c
+++ b/cursor.c
@@ -1011,9 +1011,13 @@ int mongo_cursor__do_query(zval *this_ptr, zval *return_value TSRMLS_DC)
 	mongo_read_preference_dtor(&rp);
 
 	/* Throw exception in case we have no connection */
-	if (!cursor->connection && error_message) {
-		zend_throw_exception(mongo_ce_ConnectionException, error_message, 71 TSRMLS_CC);
-		free(error_message);
+	if (!cursor->connection) {
+		if (error_message) {
+			zend_throw_exception(mongo_ce_ConnectionException, error_message, 71 TSRMLS_CC);
+			free(error_message);
+		} else {
+			zend_throw_exception(mongo_ce_ConnectionException, "Could not retrieve connection", 72 TSRMLS_CC);
+		}
 		return FAILURE;
 	}
 

--- a/php_mongo.h
+++ b/php_mongo.h
@@ -640,6 +640,7 @@ extern zend_module_entry mongo_module_entry;
  * 25: Option with no string key
  * 26: SSL support is only available when compiled against PHP Streams
  * 27: Driver options are only available when compiled against PHP Streams
+ * 72: Could not retrieve connection
  *
  * MongoCursorTimeoutException:
  * 80: timeout exception


### PR DESCRIPTION
When we don't get a cursor->connection then we always need to bail out,
not matter if we don't have a pregenerated error message
