### PR TITLE
Fixed PHP-696: mongo_io_wait_with_timeout() waits 10 seconds instead of ...

### DIFF
--- a/mcon/io.c
+++ b/mcon/io.c
@@ -42,7 +42,7 @@ int mongo_io_wait_with_timeout(int sock, int to, char **error_message)
 {
 	/* No socket timeout.. But we default to 1 second for historical reasons */
 	if (to < 1) {
-		to = 10000;
+		to = 1000;
 	}
 	while (1) {
 		int status;


### PR DESCRIPTION
...one for "no socket timeout"

This only happened if when the timeout was set to 0, not applicable in
the streams connection code
