### PR TITLE
PHP-659: Add method prototypes for GridFS classes

### DIFF
--- a/gridfs/gridfs_cursor.c
+++ b/gridfs/gridfs_cursor.c
@@ -29,6 +29,8 @@ extern zend_class_entry *mongo_ce_GridFSFile;
 
 zend_class_entry *mongo_ce_GridFSCursor = NULL;
 
+/* {{{ proto MongoGridFSCursor::__construct(MongoGridFS gridfs, resource connection, string ns, array query, array fields)
+   Creates a new MongoGridFSCursor object */
 PHP_METHOD(MongoGridFSCursor, __construct)
 {
 	zval temp;
@@ -44,13 +46,19 @@ PHP_METHOD(MongoGridFSCursor, __construct)
 
 	MONGO_METHOD4(MongoCursor, __construct, &temp, getThis(), connection, ns, query, fields);
 }
+/* }}} */
 
+/* {{{ proto MongoGridFSFile MongoGridFSCursor::getNext()
+   Return the next file to which this cursor points, and advance the cursor */
 PHP_METHOD(MongoGridFSCursor, getNext)
 {
 	MONGO_METHOD(MongoCursor, next, return_value, getThis());
 	MONGO_METHOD(MongoGridFSCursor, current, return_value, getThis());
 }
+/* }}} */
 
+/* {{{ proto MongoGridFSFile MongoGridFSCursor::current()
+   Returns the current file */
 PHP_METHOD(MongoGridFSCursor, current)
 {
 	zval temp;
@@ -73,6 +81,7 @@ PHP_METHOD(MongoGridFSCursor, current)
 	MONGO_METHOD3(MongoGridFSFile, __construct, &temp, return_value, gridfs, cursor->current, flags);
 	zval_ptr_dtor(&flags);
 }
+/* }}} */
 
 static zend_function_entry MongoGridFSCursor_methods[] = {
 	PHP_ME(MongoGridFSCursor, __construct, NULL, ZEND_ACC_PUBLIC)

--- a/gridfs/gridfs_file.c
+++ b/gridfs/gridfs_file.c
@@ -36,6 +36,8 @@ static int apply_to_cursor(zval *cursor, apply_copy_func_t apply_copy_func, void
 static int copy_bytes(void *to, char *from, int len);
 static int copy_file(void *to, char *from, int len);
 
+/* {{{ proto MongoGridFSFile::__construct(MongoGridFS gridfs, array file)
+   Creates a new MongoGridFSFile object */
 PHP_METHOD(MongoGridFSFile, __construct)
 {
 	zval *gridfs = 0, *file = 0;
@@ -52,7 +54,10 @@ PHP_METHOD(MongoGridFSFile, __construct)
 	zend_update_property(mongo_ce_GridFSFile, getThis(), "file", strlen("file"), file TSRMLS_CC);
 	zend_update_property_long(mongo_ce_GridFSFile, getThis(), "flags", strlen("flags"), flags TSRMLS_CC);
 }
+/* }}} */
 
+/* {{{ proto string MongoGridFSFile::getFilename()
+   Returns this file's filename */
 PHP_METHOD(MongoGridFSFile, getFilename)
 {
 	zval *file = zend_read_property(mongo_ce_GridFSFile, getThis(), "file", strlen("file"), NOISY TSRMLS_CC);
@@ -62,7 +67,10 @@ PHP_METHOD(MongoGridFSFile, getFilename)
 	}
 	RETURN_NULL();
 }
+/* }}} */
 
+/* {{{ proto int MongoGridFSFile::getSize()
+   Returns this file's size */
 PHP_METHOD(MongoGridFSFile, getSize)
 {
 	zval *file = zend_read_property(mongo_ce_GridFSFile, getThis(), "file", strlen("file"), NOISY TSRMLS_CC);
@@ -72,7 +80,10 @@ PHP_METHOD(MongoGridFSFile, getSize)
 	}
 	RETURN_NULL();
 }
+/* }}} */
 
+/* {{{ proto int MongoGridFSFile::write([string filename = null])
+   Writes this file to the filesystem */
 PHP_METHOD(MongoGridFSFile, write)
 {
 	char *filename = 0;
@@ -162,7 +173,10 @@ PHP_METHOD(MongoGridFSFile, write)
 
 	RETURN_LONG(total);
 }
+/* }}} */
 
+/* {{{ proto stream MongoGridFSFile::getResource()
+   Returns a resource that can be used to read the stored file */
 PHP_METHOD(MongoGridFSFile, getResource)
 {
 	php_stream * stream;
@@ -175,7 +189,10 @@ PHP_METHOD(MongoGridFSFile, getResource)
 
 	php_stream_to_zval(stream, return_value);
 }
+/* }}} */
 
+/* {{{ proto string MongoGridFSFile::getBytes()
+   Returns this file's contents as a string of bytes */
 PHP_METHOD(MongoGridFSFile, getBytes)
 {
 	zval *file, *gridfs, *chunks, *query, *cursor, *sort, *temp;
@@ -264,6 +281,7 @@ PHP_METHOD(MongoGridFSFile, getBytes)
 
 	RETURN_STRINGL(str_ptr, len, 0);
 }
+/* }}} */
 
 static int copy_bytes(void *to, char *from, int len)
 {


### PR DESCRIPTION
This replaces #281. I addressed most of the comments in the previous PR, except:
- https://github.com/mongodb/mongo-php-driver/pull/281#discussion_r2750919 - Was it important to have `$this->chunks` verbatim? I though the proto text was clear that we are dropping both collections.
- https://github.com/mongodb/mongo-php-driver/pull/281#discussion_r2751160 - `_id` can be anything, afaik.

While implementing other feedback items, I opened the following PHP tickets:
- https://jira.mongodb.org/browse/PHP-726
- https://jira.mongodb.org/browse/PHP-727
