### PR TITLE
Jenkins doesn't have pcntl (and windows probably doesn't either)

### DIFF
--- a/Makefile.servers
+++ b/Makefile.servers
@@ -1,7 +1,10 @@
-servers:
+servers: daemon
 	$(PHP_EXECUTABLE) tests/utils/make-servers.php
 
 stop-servers:
 	$(PHP_EXECUTABLE) tests/utils/teardown-servers.php
 
+daemon:
+	$(PHP_EXECUTABLE) tests/utils/daemon.php &
+	sleep 3
 

--- a/tests/utils/daemon.php
+++ b/tests/utils/daemon.php
@@ -30,7 +30,10 @@ if (!$process) {
 }
 
 stream_set_write_buffer($IO[0], 0);
-stream_set_read_buffer($IO[1], 0);
+/* Added in 5.3.3 */
+if (function_exists("stream_set_read_buffer")) {
+    stream_set_read_buffer($IO[1], 0);
+}
 
 // Say hi to the shell and read it back so we know everything is working
 $cmd = "print(" . json_encode($MARKER) . ")\n\n\n\n";


### PR DESCRIPTION
Also, setting read buffers isn't possible until 5.3.3
