### PR TITLE
Overwrite the default dbpath with the config dbpath

### DIFF
--- a/tests/utils/myconfig.js
+++ b/tests/utils/myconfig.js
@@ -54,6 +54,8 @@ function initStandalone(port,auth,root,user) {
     if (auth) {
         opts.auth = "";
     }
+
+    opts.dbpath = MongoRunner.dataPath + port;
     retval = startMongodTest(port, false, false, opts);
     retval.port = port;
     assert.soon( function() {


### PR DESCRIPTION
This should fix the issue of mongod not always listening to our $DBDIR
variable, and therefore also fix jenkins which doesn't have /data dir
