### PR TITLE
Fixed PHP-700: request/cursor mismatch

### DIFF
--- a/mcon/io.c
+++ b/mcon/io.c
@@ -136,6 +136,7 @@ int mongo_io_recv_header(int sock, mongo_server_options *options, char *reply_bu
 
 	if (status != 0) {
 		/* We don't care which failure it was, it just failed and the error_message has been set */
+		*error_message = strdup("Timed out waiting for header data");
 		return -1;
 	}
 	status = recv(sock, reply_buffer, size, 0);


### PR DESCRIPTION
Discard of the socket when we have to return a failure, such as on timeout.

Although there is technically nothing wrong with the socket, our next
read to the server will return the data we are attempting to read right
now, hence resulting in completely random reply
