### PR TITLE
Enable PHP5.2 builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
 
 notifications:
   email:
-    - bjori@php.net
+    - driver-php@10gen.com
 
 #  - cat ./.travis.scripts/script.gdb | gdb --args $MYPHP `find ...core`
 # Run PHPs run-tests.php 


### PR DESCRIPTION
Note: 5.2 doesn't have -g, so set it in the environment so the others
can pick it up.
Also, 5.2 is very picky on the extension_dir it seems, so we need to set
it, because it doesn't support relative paths from `php`
