### PR TITLE
PHP-475: Functional tests for read preference exceptions

### DIFF
--- a/tests/replicaset-failover/mongocollection-find_error-001.phpt
+++ b/tests/replicaset-failover/mongocollection-find_error-001.phpt
@@ -1,0 +1,51 @@
+--TEST--
+MongoCollection::find() MongoConnectionException no candidates due to RP
+--SKIPIF--
+<?php require_once "tests/utils/replicaset-failover.inc" ?>
+--INI--
+mongo.is_master_interval=1
+--FILE--
+<?php
+require_once 'tests/utils/server.inc';
+
+$server = new MongoShellServer();
+$rs = $server->getReplicaSetConfig();
+$mc = new MongoClient($rs['dsn'], array('replicaSet' => $rs['rsname']));
+
+$c = $mc->selectCollection(dbname(), 'mongocollection-find_error-001');
+$c->insert(array('x' => 1), array('w' => 'majority'));
+
+// Disable secondaries so query has no candidates
+$server->setMaintenanceForSecondaries(true);
+sleep(3);
+
+try {
+    $c->setReadPreference(MongoClient::RP_SECONDARY);
+    $document = $c->findOne(array('x' => 1), array('_id' => 0));
+    var_dump($document);
+} catch (MongoConnectionException $e) {
+    var_dump($e->getMessage(), $e->getCode());
+}
+
+// Enable secondaries so query can succeed
+$server->setMaintenanceForSecondaries(false);
+sleep(3);
+
+try {
+    $c->setReadPreference(MongoClient::RP_SECONDARY);
+    $document = $c->findOne(array('x' => 1), array('_id' => 0));
+    var_dump($document);
+} catch (MongoConnectionException $e) {
+    var_dump($e->getMessage(), $e->getCode());
+}
+
+?>
+--CLEAN--
+<?php require_once "tests/utils/fix-secondaries.inc"; ?>
+--EXPECTF--
+string(26) "No candidate servers found"
+int(71)
+array(1) {
+  ["x"]=>
+  int(1)
+}

--- a/tests/replicaset/mongocollection-find_error-002.phpt
+++ b/tests/replicaset/mongocollection-find_error-002.phpt
@@ -1,0 +1,40 @@
+--TEST--
+MongoCollection::find() MongoConnectionException no candidates due to RP tags
+--SKIPIF--
+<?php require_once 'tests/utils/replicaset.inc' ?>
+--FILE--
+<?php
+require_once 'tests/utils/server.inc';
+
+$rs = MongoShellServer::getReplicasetInfo();
+$mc = new MongoClient($rs['dsn'], array('replicaSet' => $rs['rsname']));
+
+$c = $mc->selectCollection(dbname(), 'mongocollection-find_error-002');
+$c->insert(array('x' => 1), array('w' => 'majority'));
+
+// Use non-matching tags so query has no candidates
+try {
+    $c->setReadPreference(MongoClient::RP_SECONDARY, array(array('dc' => 'nowhere')));
+    $document = $c->findOne(array('x' => 1), array('_id' => 0));
+    var_dump($document);
+} catch (MongoConnectionException $e) {
+    var_dump($e->getMessage(), $e->getCode());
+}
+
+// Use matching tags so query can succeed
+try {
+    $c->setReadPreference(MongoClient::RP_SECONDARY, array(array('dc' => 'ny')));
+    $document = $c->findOne(array('x' => 1), array('_id' => 0));
+    var_dump($document);
+} catch (MongoConnectionException $e) {
+    var_dump($e->getMessage(), $e->getCode());
+}
+
+?>
+--EXPECTF--
+string(26) "No candidate servers found"
+int(71)
+array(1) {
+  ["x"]=>
+  int(1)
+}


### PR DESCRIPTION
FYI: `mongocollection-find_error-001.phpt` has intermittent failures on my environment due to `replSetMaintenance` calls not sticking. Secondaries enter maintenance mode but drop out of it a second or two later, which leads to the driver sending them the query when we'd expect it not to. I get similar failures with the `mongod-recovery-mode-001.phpt` RS failover test.
