### PR TITLE
[WIP] PHP-784: Test unnecessary auth requirements for admin commands

### DIFF
--- a/tests/auth-standalone/bug00784.phpt
+++ b/tests/auth-standalone/bug00784.phpt
@@ -1,0 +1,49 @@
+--TEST--
+Test for PHP-784: Administrative commands unnecessarily require database authentication
+--SKIPIF--
+<?php require_once "tests/utils/auth-standalone.inc" ?>
+--FILE--
+<?php
+require_once "tests/utils/server.inc";
+
+$db = dbname();
+
+$s = new MongoShellServer();
+$host = $s->getStandaloneConfig(true);
+$s->addStandaloneUser($db, 'bug00784', 'foobar');
+$creds = $s->getCredentials();
+
+$options = array(
+    'db' => $db,
+    'username' => 'bug00784',
+    'password' => 'foobar',
+);
+
+$m = new MongoClient($host, $options);
+
+$c = $m->selectCollection($db, 'bug00784');
+$c->drop();
+$c->insert(array('x' => 1));
+
+var_dump($c->count());
+
+try {
+    $m->admin->command(array(
+        'renameCollection' => "$db.bug00784",
+        'to' => "$db.bug00784_renamed",
+        'dropTarget' => true,
+    ));
+} catch (MongoConnectionException $e) {
+    printf("error message: %s\n", $e->getMessage());
+    printf("error code: %d\n", $e->getCode());
+}
+
+var_dump($c->count());
+
+$c = $m->selectCollection($db, 'bug00784_renamed');
+var_dump($c->count());
+?>
+--EXPECTF--
+int(1)
+int(0)
+int(1)


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHP-784

This currently fails. If we swap the credentials for the admin user, things work swimmingly.

Likewise, I'm not able to run the isMaster command against the admin database when only authenticating against the application database to establish the connection. The shell does not impose that requirement.
