### PR TITLE
merge array value if have the same key($set). Fixed a mistake when read oplog via php

### DIFF
--- a/bson.c
+++ b/bson.c
@@ -1243,6 +1243,18 @@ char* bson_to_zval(char *buf, HashTable *result TSRMLS_DC)
 				return 0;
 			}
 		}
+		
+		/* merge the same key($set) value */
+		if ((strcmp(name, "$set") == 0) && zend_symtable_exists(result, name, strlen(name)+1) == 1) {
+		    zval **exist_value;
+
+		    if (zend_symtable_find(result, name, strlen(name)+1, (void**)&exist_value) == SUCCESS) {
+		        if (Z_TYPE_P(value) == IS_ARRAY && Z_TYPE_PP(exist_value) == IS_ARRAY) {
+		            php_array_merge(Z_ARRVAL_PP(exist_value), Z_ARRVAL_P(value), 0 TSRMLS_CC);
+		            continue;
+		        }
+		    }
+		}
 
 		zend_symtable_update(result, name, strlen(name) + 1, &value, sizeof(zval*), NULL);
 	}


### PR DESCRIPTION
First, mongodb support duplicate bson key in a collection document.

If you do an update like
`update({'uid':1}, {'$set':{'name':'foo'}, '$inc':{'count':1}})`
mongodb make an oplog document like
`{ "ts" : { "t" : 1367057935000, "i" : 2 }, "op" : "u", "ns" : "test.test", "o2" : { "_id" : ObjectId("517ba5f2f57fd86b0599a532") }, "o" : { "$set" : { "name" : 'foo' }, "$set" : { "count" : 2 } } }`
If your output is
`"o" : { "$set" : { "count" : 2 }, "$set" : { "count" : 2 } }`
i think its a bug in linux bash, the origin data stored in mongodb is the previous.

So, there are two '$set' key name in 'o' document, mongodb can parse this correctly but PHP(and other language) can't. PHP will convert the bson document to array, and PHP could't have the same key in an array.

The addition code will merge array value if the key already exists in result HashTable.

Thank you.
