### PR TITLE
Fixed PHP-805: Deprecate the "chunks" option in MongoGridFS::__construct

### DIFF
--- a/db.c
+++ b/db.c
@@ -198,7 +198,7 @@ PHP_METHOD(MongoDB, getGridFS)
 		return;
 	}
 	if (arg2) {
-		php_error_docref(NULL TSRMLS_CC, MONGO_E_DEPRECATED, "This argument doesn't do anything. Please stop sending it");
+		php_error_docref(NULL TSRMLS_CC, MONGO_E_DEPRECATED, "The 'chunks' argument is deprecated and ignored");
 	}
 
 	object_init_ex(return_value, mongo_ce_GridFS);

--- a/gridfs/gridfs.c
+++ b/gridfs/gridfs.c
@@ -76,7 +76,7 @@ static zval* insert_chunk(zval *chunks, zval *zid, int chunk_num, char *buf, int
    Creates a new MongoGridFS object */
 PHP_METHOD(MongoGridFS, __construct)
 {
-	zval *zdb, *files = 0, *chunks = 0, *zchunks;
+	zval *zdb, *files = NULL, *chunks = NULL, *zchunks;
 	zval *z_w = NULL;
 
 	/* chunks is deprecated */
@@ -84,6 +84,10 @@ PHP_METHOD(MongoGridFS, __construct)
 		zval *object = getThis();
 		ZVAL_NULL(object);
 		return;
+	}
+
+	if (chunks) {
+		php_error_docref(NULL TSRMLS_CC, MONGO_E_DEPRECATED, "The 'chunks' argument is deprecated and ignored");
 	}
 
 	if (files) {

--- a/tests/generic/bug00805.phpt
+++ b/tests/generic/bug00805.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Test for PHP-805: Deprecate the "chunks" option in MongoGridFS::__construct.
+--SKIPIF--
+<?php require "tests/utils/standalone.inc";?>
+--FILE--
+<?php
+require_once "tests/utils/server.inc";
+$mongo = mongo_standalone();
+$db = $mongo->selectDB(dbname());
+
+$gridfs = new MongoGridFS($db, "foo", "bar");
+$gridfs = $db->getGridFS("foo", "bar");
+?>
+--EXPECTF--
+%s: MongoGridFS::__construct(): The 'chunks' argument is deprecated and ignored in %sbug00805.php on line %d
+
+%s: MongoDB::getGridFS(): The 'chunks' argument is deprecated and ignored in %sbug00805.php on line %d


### PR DESCRIPTION
I've also made the message in MongoDB::getGridFS() the same.
