### PR TITLE
Fixed PHP-802: Deprecate boolean options to MongoCollection::insert().

### DIFF
--- a/log_stream.c
+++ b/log_stream.c
@@ -49,11 +49,17 @@ void mongo_log_stream_insert(mongo_connection *connection, zval *document, zval 
 		zval **args[3];
 		zval *server;
 		zval *retval = NULL;
+		int   free_options = 0;
 
 		server = php_log_get_server_info(connection);
 
 		args[0] = &server;
 		args[1] = &document;
+		if (!options) {
+			free_options = 1;
+			MAKE_STD_ZVAL(options);
+			ZVAL_NULL(options);
+		}
 		args[2] = &options;
 
 		if (FAILURE == call_user_function_ex(EG(function_table), NULL, *callback, &retval, 3, args, 0, NULL TSRMLS_CC)) {
@@ -64,6 +70,9 @@ void mongo_log_stream_insert(mongo_connection *connection, zval *document, zval 
 			zval_ptr_dtor(&retval);
 		}
 		zval_ptr_dtor(args[0]);
+		if (free_options) {
+			zval_ptr_dtor(args[2]);
+		}
 	}
 }
 

--- a/tests/generic/bug00801.phpt
+++ b/tests/generic/bug00801.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test for PHP-801: Deprecate boolean options to MongoCollection::insert().
+--SKIPIF--
+<?php require_once "tests/utils/standalone.inc"; ?>
+--FILE--
+<?php
+require_once "tests/utils/server.inc";
+$dsn = MongoShellServer::getStandaloneInfo();
+
+$m = new MongoClient($dsn);
+$d = $m->selectDB(dbname());
+$c = $d->bug801;
+$c->drop();
+
+$c->insert(array('foo' => 1), true);
+?>
+--EXPECTF--
+%s: Argument 2 passed to MongoCollection::insert() must be %s array, boolean given in %sbug00801.php on line %d

--- a/tests/mongos/stream-logger-001.phpt
+++ b/tests/mongos/stream-logger-001.phpt
@@ -82,8 +82,7 @@ array(5) {
   int(%d)
 }
 bool(true)
-array(0) {
-}
+NULL
 
 
 log_query


### PR DESCRIPTION
This removes creating artificial structures in insert(), which should make it
use less memory and speed it up. However, it pushes the checking on whether
options were passed to the places where they were used. In collection.c, there
is already another places where we do "if (options &&". log_stream.c is now
required to create an artificial structure when passing things to the logging
handler. In case no options were passed, that used to show an array(), but I
think it makes more sense to use NULL as no options (as opposed to an empty
array) were passed. This caused a test (tests/mongos/stream-logger-001.phpt) to
fail as it expected array() instead of NULL.
