### PR TITLE
Fix test for PHP-815.

### DIFF
--- a/tests/no-servers/bug00815.phpt
+++ b/tests/no-servers/bug00815.phpt
@@ -13,7 +13,7 @@ class MyDB extends MongoDB {
 $db = new MyDB;
 
 try {
-	$c = new MongoCursor(new MyMongoClient, "test");
+	$c = new MongoCursor(new MyMongoClient, "foo.test");
 } catch (MongoException $e) {
 	var_dump($e->getCode());
 	var_dump($e->getMessage());


### PR DESCRIPTION
It started failing because the fix for PHP-816 introduced an extra check on the
ns parameter which this test has wrong.
