### PR TITLE
Force native_long mode for this test to fix it on Jenkins.

### DIFF
--- a/tests/mongos/bug00755-002.phpt
+++ b/tests/mongos/bug00755-002.phpt
@@ -6,6 +6,7 @@ Test for PHP-755: Support CursorNotFound query flag (64bit, native)
 --FILE--
 <?php
 require_once "tests/utils/server.inc";
+ini_set('mongo.native_long', 1);
 
 $host = MongoShellServer::getShardInfo();
 $mc = new MongoClient($host[0]);

--- a/tests/standalone/bug00755-002.phpt
+++ b/tests/standalone/bug00755-002.phpt
@@ -6,6 +6,7 @@ Test for PHP-755: Support CursorNotFound query flag (64bit, native)
 --FILE--
 <?php
 require_once "tests/utils/server.inc";
+ini_set('mongo.native_long', 1);
 
 $host = MongoShellServer::getStandaloneInfo();
 $mc = new MongoClient($host);


### PR DESCRIPTION
Without native_long enabled, the cursor ID turned into a floating point number
which didn't (exactly) match with the real cursor ID.
