### PR TITLE
Fixed PHP-853: MongoCollection::batchInsert() exceptions can obscure BSON encoding exceptions.

### DIFF
--- a/collection.c
+++ b/collection.c
@@ -410,6 +410,7 @@ static zval* append_getlasterror(zval *coll, buffer *buf, zval *options, mongo_c
 	if (EG(exception)) {
 		zval_ptr_dtor(&cursor_z);
 		zval_ptr_dtor(&cmd_ns_z);
+		zval_ptr_dtor(&cmd);
 		return 0;
 	}
 

--- a/tests/standalone/bug00853.phpt
+++ b/tests/standalone/bug00853.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Test for PHP-853: MongoCollection::batchInsert() exceptions can obscure BSON encoding exceptions.
+--SKIPIF--
+<?php require_once "tests/utils/standalone.inc" ?>
+--FILE--
+<?php
+require_once "tests/utils/server.inc";
+
+$host = MongoShellServer::getStandaloneInfo();
+$m = new MongoClient($host);
+$c = $m->selectDb(dbname())->bug853;
+$c->drop();
+
+$document = array(
+	'foo' => 42,
+	'broken-utf8' => 'F' . chr( 180 ),
+);
+
+try {
+	$c->insert( $document );
+} catch( MongoException $e ) {
+	var_dump($e->getCode());
+	var_dump($e->getMessage());
+}
+
+try {
+	$c->batchInsert( array( $document ) );
+} catch( MongoException $e ) {
+	var_dump($e->getCode());
+	var_dump($e->getMessage());
+}
+
+?>
+--EXPECTF--
+int(12)
+string(19) "non-utf8 string: F%s"
+int(12)
+string(19) "non-utf8 string: F%s"


### PR DESCRIPTION
This also fixes a memory leak that the test case exposed.
