### PR TITLE
PHP-844: Authenticate before calling isMaster()

### DIFF
--- a/mcon/manager.c
+++ b/mcon/manager.c
@@ -102,16 +102,16 @@ static mongo_connection *mongo_get_connection_single(mongo_con_manager *manager,
 			return NULL;
 		}
 
-		/* Do authentication if requested */
-		if (!manager->authenticate(manager, con, options, server, error_message)) {
+		/* We call get_server_flags to the maxBsonObjectSize data */
+		if (!mongo_connection_get_server_flags(manager, con, options, error_message)) {
+			mongo_manager_log(manager, MLOG_CON, MLOG_WARN, "server_flags: error while getting the server configuration %s:%d: %s", server->host, server->port, *error_message);
 			mongo_connection_destroy(manager, con, MONGO_CLOSE_BROKEN);
 			free(hash);
 			return NULL;
 		}
 
-		/* We call get_server_flags to the maxBsonObjectSize data */
-		if (!mongo_connection_get_server_flags(manager, con, options, error_message)) {
-			mongo_manager_log(manager, MLOG_CON, MLOG_WARN, "server_flags: error while getting the server configuration %s:%d: %s", server->host, server->port, *error_message);
+		/* Do authentication if requested */
+		if (!manager->authenticate(manager, con, options, server, error_message)) {
 			mongo_connection_destroy(manager, con, MONGO_CLOSE_BROKEN);
 			free(hash);
 			return NULL;


### PR DESCRIPTION
This is effectively (although not literally) a revert of
c5254c76297e8c48ceef3a2f1f36f3f9c274e744

Turns out, arbiters have a issue with this so this feature has been put
on hold by mongod
