### PR TITLE
This test fails with a weird segfault somewhere in the engine on PHP 5.2

### DIFF
--- a/tests/generic/bug00320.phpt
+++ b/tests/generic/bug00320.phpt
@@ -1,6 +1,7 @@
 --TEST--
 Test for PHP-320: GridFS transaction issues with storeFile().
 --SKIPIF--
+<?php if (version_compare(PHP_VERSION, "5.3.0", "lt")) { exit("skip doesn't work on 5.2"); }?>
 <?php require_once "tests/utils/standalone.inc"; ?>
 --FILE--
 <?php


### PR DESCRIPTION
Since its on PHP 5.2 which noone cares about anyway we stick our head in
the ground and pretend it doesn't exist

Cherry-picked from master/c0e3ed572f14e9af34487e83ca8bcc4a1dc6f1ba
