### PR TITLE
Fixed PHP-874: New Replica Set connections hang when secondaries are cre...

### DIFF
--- a/mcon/connections.c
+++ b/mcon/connections.c
@@ -658,6 +658,12 @@ int mongo_connection_get_server_flags(mongo_con_manager *manager, mongo_connecti
 
 	mongo_manager_log(manager, MLOG_CON, MLOG_INFO, "get_server_flags: found server type: %s", mongo_connection_type(con->connection_type));
 
+	if (con->connection_type == MONGO_NODE_INVALID) {
+		*error_message = strdup("get_server_flags: got unknown node type");
+		free(data_buffer);
+		return 0;
+	}
+
 	/* Find read preferences tags */
 	con->tag_count = 0;
 	con->tags = NULL;


### PR DESCRIPTION
...ating indexes during initialSync

When checking the node type, we should drop unknown mbers right away!

If we don't drop the connection here we will continue and try to
authenticate - which will attempt to take a lock on the server..
which will go so well during initial sync and index creations for
example.

This was "only" a problem when using authentication, as even if we
had the connection around normally, we don't have read preferences
that would use it so no harm no faul, just a silly thing to keep around
