### PR TITLE
PHP-892: Add rudimentary master/slave support

### DIFF
--- a/mcon/manager.c
+++ b/mcon/manager.c
@@ -282,7 +282,7 @@ static mongo_connection *mongo_get_read_write_connection_replicaset(mongo_con_ma
 		tmp_rp.tagsets = NULL;
 		tmp_rp.tagset_count = 0;
 
-		collection = mongo_find_candidate_servers(manager, &tmp_rp, servers);
+		collection = mongo_find_candidate_servers(manager, &tmp_rp, servers, connection_flags);
 		mongo_read_preference_dtor(&tmp_rp);
 	} else if (connection_flags & MONGO_CON_FLAG_DONT_FILTER) {
 		/* We just want to know if we have something to talk to, irregardless of RP */
@@ -292,10 +292,10 @@ static mongo_connection *mongo_get_read_write_connection_replicaset(mongo_con_ma
 		tmp_rp.tagsets = NULL;
 		tmp_rp.tagset_count = 0;
 
-		collection = mongo_find_candidate_servers(manager, &tmp_rp, servers);
+		collection = mongo_find_candidate_servers(manager, &tmp_rp, servers, connection_flags);
 		mongo_read_preference_dtor(&tmp_rp);
 	} else {
-		collection = mongo_find_candidate_servers(manager, &servers->read_pref, servers);
+		collection = mongo_find_candidate_servers(manager, &servers->read_pref, servers, connection_flags);
 	}
 	if (!collection) {
 		*error_message = strdup("No candidate servers found");
@@ -361,7 +361,7 @@ static mongo_connection *mongo_get_connection_multiple(mongo_con_manager *manage
 	tmp_rp.type = MONGO_RP_NEAREST;
 	tmp_rp.tagsets = NULL;
 	tmp_rp.tagset_count = 0;
-	collection = mongo_find_candidate_servers(manager, &tmp_rp, servers);
+	collection = mongo_find_candidate_servers(manager, &tmp_rp, servers, connection_flags);
 	if (!collection || collection->count == 0) {
 		if (messages->l) {
 			*error_message = strdup(messages->d);

--- a/mcon/read_preference.h
+++ b/mcon/read_preference.h
@@ -35,7 +35,7 @@
 
 typedef int (mongo_connection_sort_t)(const void *a, const void *b);
 
-mcon_collection* mongo_find_candidate_servers(mongo_con_manager *manager, mongo_read_preference *rp, mongo_servers *servers);
+mcon_collection* mongo_find_candidate_servers(mongo_con_manager *manager, mongo_read_preference *rp, mongo_servers *servers, int connection_flags);
 mcon_collection *mongo_sort_servers(mongo_con_manager *manager, mcon_collection *col, mongo_read_preference *rp);
 mcon_collection *mongo_select_nearest_servers(mongo_con_manager *manager, mcon_collection *col, mongo_read_preference *rp);
 mongo_connection *mongo_pick_server_from_set(mongo_con_manager *manager, mcon_collection *col, mongo_read_preference *rp);


### PR DESCRIPTION
It is detected as a "MULTIPLE", since there is no concept of a set name.
The master is detected as a standalone node as we can't differnciate it
from a standalone connection (without adding a new "master/slave" option
to the $options array), but the slave will be marked as a secondary node
(without replicaset).

When getting a writable connection we will filter out the slave, but for
read connections we simply select the "nearest" node.
