### PR TITLE
Fixed PHP-773: Fix the persistence issue with logging stream contexts

### DIFF
--- a/mcon/manager.c
+++ b/mcon/manager.c
@@ -523,6 +523,15 @@ void *mongo_manager_find_by_hash(mongo_con_manager *manager, mongo_con_manager_i
 	return NULL;
 }
 
+mongo_connection *mongo_manager_connection_find_by_server_def(mongo_con_manager *manager, mongo_server_def *def)
+{
+	char *hash = mongo_server_create_hash(def);
+	mongo_connection *con = mongo_manager_find_by_hash(manager, manager->connections, hash);
+
+	free(hash);
+	return con;
+}
+
 mongo_connection *mongo_manager_connection_find_by_hash(mongo_con_manager *manager, char *hash)
 {
 	return mongo_manager_find_by_hash(manager, manager->connections, hash);

--- a/mcon/manager.h
+++ b/mcon/manager.h
@@ -29,6 +29,8 @@ mongo_connection *mongo_get_read_write_connection(mongo_con_manager *manager, mo
 mongo_connection *mongo_get_read_write_connection_with_callback(mongo_con_manager *manager, mongo_servers *servers, int connection_flags, void *callback_data, mongo_cleanup_t cleanup_cb, char **error_message);
 
 /* Connection management */
+
+mongo_connection *mongo_manager_connection_find_by_server_def(mongo_con_manager *manager, mongo_server_def *def);
 mongo_connection *mongo_manager_connection_find_by_hash(mongo_con_manager *manager, char *hash);
 void mongo_manager_connection_register(mongo_con_manager *manager, mongo_connection *con);
 int mongo_manager_connection_deregister(mongo_con_manager *manager, mongo_connection *con);

--- a/mongoclient.c
+++ b/mongoclient.c
@@ -531,14 +531,23 @@ void php_mongo_ctor(INTERNAL_FUNCTION_PARAMETERS, int bc)
 	}
 #endif
 
-	if (zdoptions) {
-		/* Possibly add more indexes in the future, like "log_queries",
-		 * "log_commands", "log_failures", "log_metadata"... */
+	{
+		int i = 0;
 		zval **zcontext;
+		php_stream_context *ctx = NULL;
 
-		if (zend_hash_find(Z_ARRVAL_P(zdoptions), "context", strlen("context") + 1, (void**)&zcontext) == SUCCESS) {
-			link->servers->options.ctx = php_stream_context_from_zval(*zcontext, PHP_FILE_NO_DEFAULT_CONTEXT);
+		if (zdoptions && zend_hash_find(Z_ARRVAL_P(zdoptions), "context", strlen("context") + 1, (void**)&zcontext) == SUCCESS) {
 			mongo_manager_log(link->manager, MLOG_CON, MLOG_INFO, "Found Stream context");
+			ctx = php_stream_context_from_zval(*zcontext, PHP_FILE_NO_DEFAULT_CONTEXT);
+		}
+		link->servers->options.ctx = ctx;
+
+		for (i = 0; i < link->servers->count; i++) {
+			mongo_connection *con = mongo_manager_connection_find_by_server_def(link->manager, link->servers->server[i]);
+
+			if (con) {
+				php_stream_context_set(con->socket, ctx);
+			}
 		}
 	}
 


### PR DESCRIPTION
Each time we instanciate MongoClient we will iterate over open servers
and apply the current stream contexts.
This will overwrite previously set contexts with the new one or reset it
to NULL if no context was provided.

If there are no open streams, we assign the context to the server
options and it will be used when creating new streams like before
