### PR TITLE
Fixed PHP-902: Segfault when unregistering broken server 

### DIFF
--- a/mcon/manager.c
+++ b/mcon/manager.c
@@ -208,8 +208,8 @@ static void mongo_discover_topology(mongo_con_manager *manager, mongo_servers *s
 						new_con = mongo_get_connection_single(manager, tmp_def, &servers->options, MONGO_CON_FLAG_WRITE, (char **) &con_error_message);
 
 						if (!mongo_connection_get_server_flags(manager, new_con, &servers->options, &con_error_message)) {
-							mongo_manager_log(manager, MLOG_CON, MLOG_WARN, "server_flags: error while getting the server configuration %s:%d: %s", servers->server[i]->host, servers->server[i]->port, error_message);
-							mongo_connection_destroy(manager, new_con, MONGO_CLOSE_BROKEN);
+							mongo_manager_log(manager, MLOG_CON, MLOG_WARN, "server_flags: error while getting the server configuration %s:%d: %s", servers->server[i]->host, servers->server[i]->port, con_error_message);
+							mongo_manager_connection_deregister(manager, new_con);
 							new_con = NULL;
 						}
 


### PR DESCRIPTION
This fixes a segfault in the mongocollection-find_error-001.phpt failover test

When the server doesn't work, we need to unregister it from the manager,
otherwise we keep a dangling pointer to it, and crash when we try to
locate servers to use.

Also fix invalid read, using the wrong error variable on error
