### PR TITLE
PHP-907: BSON DBPointer decoding should set MongoId $id property

### DIFF
--- a/bson.c
+++ b/bson.c
@@ -1147,7 +1147,7 @@ char* bson_to_zval(char *buf, HashTable *result TSRMLS_DC)
 			case BSON_DBREF: {
 				int ns_len;
 				char *ns;
-				zval *zoid;
+				zval *zoid, *str = 0;
 				mongo_id *this_id;
 
 				/* ns */
@@ -1167,6 +1167,13 @@ char* bson_to_zval(char *buf, HashTable *result TSRMLS_DC)
 
 				this_id = (mongo_id*)zend_object_store_get_object(zoid TSRMLS_CC);
 				this_id->id = estrndup(buf, OID_SIZE);
+
+				MAKE_STD_ZVAL(str);
+				ZVAL_NULL(str);
+
+				MONGO_METHOD(MongoId, __toString, str, zoid);
+				zend_update_property(mongo_ce_Id, zoid, "$id", strlen("$id"), str TSRMLS_CC);
+				zval_ptr_dtor(&str);
 
 				buf += OID_SIZE;
 

--- a/tests/no-servers/bug00907.phpt
+++ b/tests/no-servers/bug00907.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Test for PHP-896: Segfault decoding BSON reads past buffer endpoint
+--SKIPIF--
+<?php require dirname(__FILE__) ."/skipif.inc"; ?>
+--FILE--
+<?php
+
+function createDBPointer($ns, $oid) {
+    $bson  = pack('C', 0x0C);                      // byte: field type
+    $bson .= pack('a*x', 'x');                     // cstring: field name
+    $bson .= pack('V', strlen($ns) + 1);           // int32: namespace string length
+    $bson .= pack('a*x', $ns);                     // cstring: namespace string value
+    $bson .= pack('H*', $oid);                     // ObjectId bytes
+    $bson .= pack('x');                            // null byte: document terminator
+    $bson  = pack('V', 4 + strlen($bson)) . $bson; // int32: document length
+
+    return $bson;
+}
+
+var_dump(bson_decode(createDBPointer('foo.bar', '522f2461e84df1f6378b4567')));
+
+?>
+--EXPECTF--
+
+array(1) {
+  ["x"]=>
+  array(2) {
+    ["$ref"]=>
+    string(7) "foo.bar"
+    ["$id"]=>
+    object(MongoId)#%d (1) {
+      ["$id"]=>
+      string(24) "522f2461e84df1f6378b4567"
+    }
+  }
+}


### PR DESCRIPTION
See: https://jira.mongodb.org/browse/PHP-907

This mimics what is already done during ObjectId decoding. Without updating the `$id` property of the object, only the internal `id` property of the `mongo_id` struct is set (with a C string).
