### PR TITLE
Fix memory leak during code_ws BSON decoding

### DIFF
--- a/bson.c
+++ b/bson.c
@@ -1167,10 +1167,6 @@ char* bson_to_zval(char *buf, HashTable *result TSRMLS_DC)
 				code = buf;
 				buf += code_len;
 
-				/* initialize scope array */
-				MAKE_STD_ZVAL(zcope);
-				array_init(zcope);
-
 				if (type == BSON_CODE) {
 					int scope_len;
 
@@ -1180,11 +1176,19 @@ char* bson_to_zval(char *buf, HashTable *result TSRMLS_DC)
 
 					CHECK_BUFFER_LEN(scope_len);
 
+					/* initialize scope array */
+					MAKE_STD_ZVAL(zcope);
+					array_init(zcope);
+
 					buf = bson_to_zval(buf, HASH_P(zcope) TSRMLS_CC);
 					if (EG(exception)) {
 						zval_ptr_dtor(&zcope);
 						return 0;
 					}
+				} else {
+					/* initialize an empty scope array */
+					MAKE_STD_ZVAL(zcope);
+					array_init(zcope);
 				}
 
 				object_init_ex(value, mongo_ce_Code);


### PR DESCRIPTION
See: bdcbc9586c3468432be663d3500e6941e395c590 (PR #520 fix for PHP-896)

Fixes the following Jenkins failure: https://jenkins.10gen.com/job/mongo-php-driver/mongodb_configuration=single_server,mongodb_server=legacy-release,os_arch=linux64,php_language_version=5.3/238/testReport/junit/php-src.tests/no-servers/bug00896_code_ws_phpt___Test_for_PHP_896__Segfault_decoding_BSON_reads_past_buffer_endpoint__code_ws_/
