### PR TITLE
Implemented PHP-955: Switch the default mongo.native_long to 1 for 64 bit platforms.

### DIFF
--- a/php_mongo.c
+++ b/php_mongo.c
@@ -149,7 +149,11 @@ PHP_INI_BEGIN()
 	STD_PHP_INI_ENTRY("mongo.default_port", "27017", PHP_INI_ALL, OnUpdateLong, default_port, zend_mongo_globals, mongo_globals)
 	STD_PHP_INI_ENTRY("mongo.chunk_size", "262144", PHP_INI_ALL, OnUpdateLong, chunk_size, zend_mongo_globals, mongo_globals)
 	STD_PHP_INI_ENTRY("mongo.cmd", "$", PHP_INI_ALL, OnUpdateStringUnempty, cmd_char, zend_mongo_globals, mongo_globals)
+#if SIZEOF_LONG == 4
 	STD_PHP_INI_ENTRY("mongo.native_long", "0", PHP_INI_ALL, OnUpdateLong, native_long, zend_mongo_globals, mongo_globals)
+#else
+	STD_PHP_INI_ENTRY("mongo.native_long", "1", PHP_INI_ALL, OnUpdateLong, native_long, zend_mongo_globals, mongo_globals)
+#endif
 	STD_PHP_INI_ENTRY("mongo.long_as_object", "0", PHP_INI_ALL, OnUpdateLong, long_as_object, zend_mongo_globals, mongo_globals)
 	STD_PHP_INI_ENTRY("mongo.allow_empty_keys", "0", PHP_INI_ALL, OnUpdateLong, allow_empty_keys, zend_mongo_globals, mongo_globals)
 

--- a/tests/replicaset/mongocollection-find_error-002.phpt
+++ b/tests/replicaset/mongocollection-find_error-002.phpt
@@ -33,7 +33,7 @@ try {
 ?>
 --EXPECTF--
 string(26) "No candidate servers found"
-int(71)
+%s(71)
 array(1) {
   ["x"]=>
   int(1)


### PR DESCRIPTION
We can not do this for 32 bit platforms, as then all sorts of internal things go wrong, with commands etc. For 64 bit platforms native long makes sense, whereas 32 bit platforms are going to be crippled anyway. I think it's better to just have this set to "1" for 64 bit platforms only by default.
