### PR TITLE
fix build error under FreeBSD 7.x.

### DIFF
--- a/mcon/types.h
+++ b/mcon/types.h
@@ -37,6 +37,7 @@ typedef unsigned __int64 uint64_t;
 #endif
 #else
 # include <stdint.h>
+# include <sys/types.h>
 # include <netinet/in.h>
 # include <netinet/tcp.h>
 # include <fcntl.h>


### PR DESCRIPTION
sys/types.h must be included before sys/socket.h on certain older BSD variants.

/usr/include/netinet/tcp.h:40: error: expected '=', ',', ';', 'asm' or '**attribute**' before 'tcp_seq'
