### PR TITLE
PHP-962: Define constants for MongoBinData subtypes 0 and 4

### DIFF
--- a/tests/generic/mongobindata-004.phpt
+++ b/tests/generic/mongobindata-004.phpt
@@ -9,11 +9,14 @@ $mongo = mongo_standalone();
 $coll = $mongo->selectCollection(dbname(), 'mongobindata');
 $coll->drop();
 
+$coll->insert(array('bin' => new MongoBinData('pqr', MongoBinData::GENERIC)));
 $coll->insert(array('bin' => new MongoBinData('abc', MongoBinData::FUNC)));
 $coll->insert(array('bin' => new MongoBinData('def', MongoBinData::BYTE_ARRAY)));
 $coll->insert(array('bin' => new MongoBinData('ghi', MongoBinData::UUID)));
+$coll->insert(array('bin' => new MongoBinData('stu', MongoBinData::UUID_RFC4122)));
 $coll->insert(array('bin' => new MongoBinData('jkl', MongoBinData::MD5)));
 $coll->insert(array('bin' => new MongoBinData('mno', MongoBinData::CUSTOM)));
+
 
 $cursor = $coll->find();
 
@@ -22,8 +25,10 @@ foreach ($cursor as $result) {
 }
 ?>
 --EXPECT--
+Type 0 with data "pqr"
 Type 1 with data "abc"
 Type 2 with data "def"
 Type 3 with data "ghi"
+Type 4 with data "stu"
 Type 5 with data "jkl"
 Type 128 with data "mno"

--- a/tests/no-servers/mongobindata-005.phpt
+++ b/tests/no-servers/mongobindata-005.phpt
@@ -4,15 +4,19 @@ MongoBinData type constants
 <?php require_once dirname(__FILE__) . "/skipif.inc"; ?>
 --FILE--
 <?php
-echo MongoBinData::FUNC . "\n";
-echo MongoBinData::BYTE_ARRAY . "\n";
-echo MongoBinData::UUID . "\n";
-echo MongoBinData::MD5 . "\n";
-echo MongoBinData::CUSTOM . "\n";
+var_dump(MongoBinData::GENERIC);
+var_dump(MongoBinData::FUNC);
+var_dump(MongoBinData::BYTE_ARRAY);
+var_dump(MongoBinData::UUID);
+var_dump(MongoBinData::UUID_RFC4122);
+var_dump(MongoBinData::MD5);
+var_dump(MongoBinData::CUSTOM);
 ?>
 --EXPECT--
-1
-2
-3
-5
-128
+int(0)
+int(1)
+int(2)
+int(3)
+int(4)
+int(5)
+int(128)

--- a/types/bin_data.c
+++ b/types/bin_data.c
@@ -15,6 +15,7 @@
  */
 #include <php.h>
 #include "../php_mongo.h"
+#include "bin_data.h"
 
 zend_class_entry *mongo_ce_BinData = NULL;
 
@@ -67,13 +68,15 @@ void mongo_init_MongoBinData(TSRMLS_D)
 	zend_declare_property_long(mongo_ce_BinData, "type", strlen("type"), 0, ZEND_ACC_PUBLIC|MONGO_ACC_READ_ONLY TSRMLS_CC);
 
 	/* constants */
+	zend_declare_class_constant_long(mongo_ce_BinData, "GENERIC", strlen("GENERIC"), BIN_GENERIC TSRMLS_CC);
 	/* can't use FUNCTION because it's a reserved word */
-	zend_declare_class_constant_long(mongo_ce_BinData, "FUNC", strlen("FUNC"), 0x01 TSRMLS_CC);
+	zend_declare_class_constant_long(mongo_ce_BinData, "FUNC", strlen("FUNC"), BIN_FUNC TSRMLS_CC);
 	/* can't use ARRAY because it's a reserved word */
-	zend_declare_class_constant_long(mongo_ce_BinData, "BYTE_ARRAY", strlen("BYTE_ARRAY"), 0x02 TSRMLS_CC);
-	zend_declare_class_constant_long(mongo_ce_BinData, "UUID", strlen("UUID"), 0x03 TSRMLS_CC);
-	zend_declare_class_constant_long(mongo_ce_BinData, "MD5", strlen("MD5"), 0x05 TSRMLS_CC);
-	zend_declare_class_constant_long(mongo_ce_BinData, "CUSTOM", strlen("CUSTOM"), 0x80 TSRMLS_CC);
+	zend_declare_class_constant_long(mongo_ce_BinData, "BYTE_ARRAY", strlen("BYTE_ARRAY"), BIN_BYTE_ARRAY TSRMLS_CC);
+	zend_declare_class_constant_long(mongo_ce_BinData, "UUID", strlen("UUID"), BIN_UUID TSRMLS_CC);
+	zend_declare_class_constant_long(mongo_ce_BinData, "UUID_RFC4122", strlen("UUID_RFC4122"), BIN_UUID_RFC4122 TSRMLS_CC);
+	zend_declare_class_constant_long(mongo_ce_BinData, "MD5", strlen("MD5"), BIN_MD5 TSRMLS_CC);
+	zend_declare_class_constant_long(mongo_ce_BinData, "CUSTOM", strlen("CUSTOM"), BIN_CUSTOM TSRMLS_CC);
 }
 
 /*

--- a/types/bin_data.h
+++ b/types/bin_data.h
@@ -16,11 +16,13 @@
 #ifndef __TYPES_BIN_DATA_H__
 #define __TYPES_BIN_DATA_H__
 
-#define BIN_FUNCTION 1
-#define BIN_BYTE_ARRAY 2
-#define BIN_UUID 3
-#define BIN_MD5 5
-#define BIN_CUSTOM 128
+#define BIN_GENERIC      0x00
+#define BIN_FUNC         0x01
+#define BIN_BYTE_ARRAY   0x02
+#define BIN_UUID         0x03
+#define BIN_UUID_RFC4122 0x04
+#define BIN_MD5          0x05
+#define BIN_CUSTOM       0x80
 
 PHP_METHOD(MongoBinData, __construct);
 PHP_METHOD(MongoBinData, __toString);


### PR DESCRIPTION
Subtype 0 is the new default (to be changed in PHP-407), which replaces deprecated subtype 2. Subtype 4 is the new UUID type, which enforces the RFC spec, to replace deprecated subtype 3.

Additionally, replace hard-coded values in bin_data.c with the defined constants.
