### PR TITLE
Specify default $log arg value for DebugException

### DIFF
--- a/tests/utils/server.inc
+++ b/tests/utils/server.inc
@@ -295,7 +295,7 @@ class MongoShellServer {
 }
 
 class DebugException extends Exception {
-    public function __construct($msg, $log) {
+    public function __construct($msg, $log = null) {
         parent::__construct($msg);
         $this->log = $log;
     }


### PR DESCRIPTION
When mongobridge is not found, this exception is thrown and there is no `$log` available to use.
