### PR TITLE
PHP-819: Fix MongoCollection::setWriteConcern() and split tests

### DIFF
--- a/collection.c
+++ b/collection.c
@@ -231,7 +231,7 @@ PHP_METHOD(MongoCollection, setWriteConcern)
 	}
 
 	if (Z_TYPE_P(write_concern) == IS_LONG) {
-		zend_update_property_long(mongo_ce_Collection, getThis(), "w", strlen("w"), 3 TSRMLS_CC);
+		zend_update_property_long(mongo_ce_Collection, getThis(), "w", strlen("w"), Z_LVAL_P(write_concern) TSRMLS_CC);
 	} else if (Z_TYPE_P(write_concern) == IS_STRING) {
 		zend_update_property_stringl(mongo_ce_Collection, getThis(), "w", strlen("w"), Z_STRVAL_P(write_concern), Z_STRLEN_P(write_concern) TSRMLS_CC);
 	} else {

--- a/tests/standalone/mongocollection-setwriteconcern-001.phpt
+++ b/tests/standalone/mongocollection-setwriteconcern-001.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test for MongoDB->setWriteConcern()
+MongoCollection::setWriteConcern() and MongoCollection::getWriteConcern()
 --SKIPIF--
 <?php require_once "tests/utils/standalone.inc" ?>
 --FILE--
@@ -7,62 +7,43 @@ Test for MongoDB->setWriteConcern()
 require_once "tests/utils/server.inc";
 
 $host = MongoShellServer::getStandaloneInfo();
-$mc = new MongoClient($host);
+$mc = new MongoClient($host, array('w' => 2, 'wTimeoutMS' => 400));
 
-$db = $mc->selectDb(dbname());
+$c = $mc->selectCollection(dbname(), collname(__FILE__));
 
-var_dump($db->getWriteConcern());
-var_dump($db->setWriteConcern(3, 400));
-var_dump($db->getWriteConcern());
-var_dump($db->setWriteConcern(0));
-var_dump($db->getWriteConcern());
-
-$c = $db->wc;
+var_dump($c->getWriteConcern());
+var_dump($c->setWriteConcern(0));
 var_dump($c->getWriteConcern());
 var_dump($c->setWriteConcern(1, 1000));
 var_dump($c->getWriteConcern());
-var_dump($c->setWriteConcern(2));
+var_dump($c->setWriteConcern('majority'));
 var_dump($c->getWriteConcern());
 ?>
 --EXPECT--
 array(2) {
   ["w"]=>
+  int(2)
+  ["wtimeout"]=>
+  int(400)
+}
+bool(true)
+array(2) {
+  ["w"]=>
+  int(0)
+  ["wtimeout"]=>
+  int(400)
+}
+bool(true)
+array(2) {
+  ["w"]=>
   int(1)
   ["wtimeout"]=>
-  int(10000)
-}
-bool(true)
-array(2) {
-  ["w"]=>
-  int(3)
-  ["wtimeout"]=>
-  int(400)
-}
-bool(true)
-array(2) {
-  ["w"]=>
-  int(0)
-  ["wtimeout"]=>
-  int(400)
-}
-array(2) {
-  ["w"]=>
-  int(0)
-  ["wtimeout"]=>
-  int(400)
-}
-bool(true)
-array(2) {
-  ["w"]=>
-  int(3)
-  ["wtimeout"]=>
   int(1000)
 }
 bool(true)
 array(2) {
   ["w"]=>
-  int(3)
+  string(8) "majority"
   ["wtimeout"]=>
   int(1000)
 }
-

--- a/tests/standalone/mongodb-setwriteconcern-001.phpt
+++ b/tests/standalone/mongodb-setwriteconcern-001.phpt
@@ -1,0 +1,50 @@
+--TEST--
+MongoDB::setWriteConcern() and MongoDB::getWriteConcern()
+--SKIPIF--
+<?php require_once "tests/utils/standalone.inc" ?>
+--FILE--
+<?php
+require_once "tests/utils/server.inc";
+
+$host = MongoShellServer::getStandaloneInfo();
+$mc = new MongoClient($host, array('w' => 2, 'wTimeoutMS' => 400));
+
+$db = $mc->selectDB(dbname());
+
+var_dump($db->getWriteConcern());
+var_dump($db->setWriteConcern(0));
+var_dump($db->getWriteConcern());
+var_dump($db->setWriteConcern(1, 1000));
+var_dump($db->getWriteConcern());
+var_dump($db->setWriteConcern('majority'));
+var_dump($db->getWriteConcern());
+
+?>
+--EXPECT--
+array(2) {
+  ["w"]=>
+  int(2)
+  ["wtimeout"]=>
+  int(400)
+}
+bool(true)
+array(2) {
+  ["w"]=>
+  int(0)
+  ["wtimeout"]=>
+  int(400)
+}
+bool(true)
+array(2) {
+  ["w"]=>
+  int(1)
+  ["wtimeout"]=>
+  int(1000)
+}
+bool(true)
+array(2) {
+  ["w"]=>
+  string(8) "majority"
+  ["wtimeout"]=>
+  int(1000)
+}


### PR DESCRIPTION
Fixes a bug from cd67c8910b483b6ef5324589b5e0c33b6e4325fb, where integer $w arguments to setWriteConcern() were set as 3.

This also splits the MongoDB and MongoCollection tests, and adds additional test cases for string $w values, inheriting MongoClient (parent) write concerns, and setting the timeout.
