### PR TITLE
PHP-1009: JSON is optional at buildtime but requires at runtime

### DIFF
--- a/php_mongo.c
+++ b/php_mongo.c
@@ -96,7 +96,11 @@ zend_function_entry mongo_functions[] = {
  */
 static const zend_module_dep mongo_deps[] = {
 	ZEND_MOD_OPTIONAL("openssl")
+#if HAVE_JSON
+	ZEND_MOD_REQUIRED("json")
+#else
 	ZEND_MOD_OPTIONAL("json")
+#endif
 #if PHP_VERSION_ID >= 50307
 	ZEND_MOD_END
 #else /* pre-5.3.7 */


### PR DESCRIPTION
If you compile PHP with --enable-json=shared you'll HAVE_JSON
However, if you don't have extension=json in your PHP.ini.. HAVE_JSON
will still pretend to be there, and we eventually hit
Symbol not found: _php_json_encode

When built against json we need to require it to be loaded.
When we don't build against json, we report it normally as optional
Although, if you then compile and install json.. we won't actually know that
as we'll still think HAVE_JSON is 0 :]
There doesn't seem to be a real solution for this in PHP :/
