### PR TITLE
Remove extra reset() method.

### DIFF
--- a/command_cursor.c
+++ b/command_cursor.c
@@ -409,14 +409,6 @@ PHP_METHOD(MongoCommandCursor, key)
 }
 /* }}} */
 
-/* {{{ MongoCommandCursor::reset()
-   Does nothing yet. */
-PHP_METHOD(MongoCommandCursor, reset)
-{
-	printf("reset\n");
-}
-/* }}} */
-
 static zend_function_entry MongoCommandCursor_methods[] = {
 	PHP_ME(MongoCommandCursor, __construct, arginfo___construct, ZEND_ACC_CTOR|ZEND_ACC_PUBLIC)
 
@@ -433,7 +425,6 @@ static zend_function_entry MongoCommandCursor_methods[] = {
 	PHP_ME(MongoCommandCursor, next, arginfo_no_parameters, ZEND_ACC_PUBLIC)
 	PHP_ME(MongoCommandCursor, rewind, arginfo_no_parameters, ZEND_ACC_PUBLIC)
 	PHP_ME(MongoCommandCursor, valid, arginfo_no_parameters, ZEND_ACC_PUBLIC)
-	PHP_ME(MongoCommandCursor, reset, arginfo_no_parameters, ZEND_ACC_PUBLIC)
 
 	PHP_FE_END
 };

--- a/tests/no-servers/bug00270-arginfo.phpt
+++ b/tests/no-servers/bug00270-arginfo.phpt
@@ -311,7 +311,6 @@ MongoCommandCursor
   Method next expects 0 parameters
   Method rewind expects 0 parameters
   Method valid expects 0 parameters
-  Method reset expects 0 parameters
 
 MongoPool
   Method info expects 0 parameters


### PR DESCRIPTION
I honestly thought it was part of Iterator, but it is not :-)

I did see whether it was necessary to iterate over a command cursor twice as well, but it is not. You can just do:

$c = $col->commandCursor();
foreach ( $c ) { ... }
foreach ( $c ) { ... }
