### PR TITLE
PHP-1041: Fix off-by-one error in MongoCommandCursor::key() indexes

### DIFF
--- a/command_cursor.c
+++ b/command_cursor.c
@@ -380,9 +380,9 @@ PHP_METHOD(MongoCommandCursor, key)
 	}
 
 	if (cmd_cursor->first_batch) {
-		RETURN_LONG(cmd_cursor->first_batch_at - 1);
+		RETURN_LONG(cmd_cursor->first_batch_at);
 	} else {
-		RETURN_LONG(cmd_cursor->first_batch_num + cmd_cursor->at - 1);
+		RETURN_LONG(cmd_cursor->first_batch_num + cmd_cursor->at);
 	}
 }
 /* }}} */

--- a/tests/generic/mongocollection-aggregatecursor-001.phpt
+++ b/tests/generic/mongocollection-aggregatecursor-001.phpt
@@ -49,7 +49,7 @@ foreach ($cursor as $key => $record) {
 Issuing command: drop
 Cursor class: MongoCommandCursor
 Issuing command: aggregate
-int(-1)
+int(0)
 array(2) {
   ["_id"]=>
   object(MongoId)#%d (1) {

--- a/tests/generic/mongocollection-aggregatecursor-002.phpt
+++ b/tests/generic/mongocollection-aggregatecursor-002.phpt
@@ -49,7 +49,7 @@ foreach ($cursor as $key => $record) {
 Issuing command: drop
 Cursor class: MongoCommandCursor
 Issuing command: aggregate
-int(-1)
+int(0)
 array(2) {
   ["_id"]=>
   object(MongoId)#%d (1) {
@@ -59,7 +59,7 @@ array(2) {
   ["article_id"]=>
   int(0)
 }
-int(0)
+int(1)
 array(2) {
   ["_id"]=>
   object(MongoId)#%d (1) {

--- a/tests/generic/mongocollection-aggregatecursor-003.phpt
+++ b/tests/generic/mongocollection-aggregatecursor-003.phpt
@@ -49,7 +49,7 @@ foreach ($cursor as $key => $record) {
 Issuing command: drop
 Cursor class: MongoCommandCursor
 Issuing command: aggregate
-int(-1)
+int(0)
 array(2) {
   ["_id"]=>
   object(MongoId)#%d (1) {
@@ -59,7 +59,7 @@ array(2) {
   ["article_id"]=>
   int(0)
 }
-int(0)
+int(1)
 array(2) {
   ["_id"]=>
   object(MongoId)#%d (1) {
@@ -70,7 +70,7 @@ array(2) {
   int(1)
 }
 Issuing getmore
-int(1)
+int(2)
 array(2) {
   ["_id"]=>
   object(MongoId)#%d (1) {
@@ -80,7 +80,7 @@ array(2) {
   ["article_id"]=>
   int(2)
 }
-int(2)
+int(3)
 array(2) {
   ["_id"]=>
   object(MongoId)#%d (1) {
@@ -91,7 +91,7 @@ array(2) {
   int(3)
 }
 Issuing getmore
-int(3)
+int(4)
 array(2) {
   ["_id"]=>
   object(MongoId)#%d (1) {

--- a/tests/generic/mongocollection-aggregatecursor-004.phpt
+++ b/tests/generic/mongocollection-aggregatecursor-004.phpt
@@ -53,7 +53,7 @@ Issuing command: drop
 Cursor class: MongoCommandCursor
 Issuing command: aggregate
 Cursor batch size: 101
-int(-1)
+int(0)
 array(2) {
   ["_id"]=>
   object(MongoId)#%d (1) {
@@ -63,7 +63,7 @@ array(2) {
   ["article_id"]=>
   int(0)
 }
-int(0)
+int(1)
 array(2) {
   ["_id"]=>
   object(MongoId)#%d (1) {

--- a/tests/generic/mongocollection-aggregatecursor-005.phpt
+++ b/tests/generic/mongocollection-aggregatecursor-005.phpt
@@ -54,7 +54,7 @@ Issuing command: drop
 Cursor class: MongoCommandCursor
 Issuing command: aggregate
 Cursor batch size: 101
-int(-1)
+int(0)
 array(2) {
   ["_id"]=>
   object(MongoId)#%d (1) {
@@ -64,7 +64,7 @@ array(2) {
   ["article_id"]=>
   int(0)
 }
-int(0)
+int(1)
 array(2) {
   ["_id"]=>
   object(MongoId)#%d (1) {

--- a/tests/generic/mongocommandcursor-002.phpt
+++ b/tests/generic/mongocommandcursor-002.phpt
@@ -33,7 +33,7 @@ foreach ($c as $key => $record) {
 }
 ?>
 --EXPECTF--
-int(-1)
+int(0)
 array(2) {
   ["_id"]=>
   object(MongoId)#%d (1) {
@@ -43,7 +43,7 @@ array(2) {
   ["article_id"]=>
   int(0)
 }
-int(0)
+int(1)
 array(2) {
   ["_id"]=>
   object(MongoId)#%d (1) {

--- a/tests/generic/mongocommandcursor-003.phpt
+++ b/tests/generic/mongocommandcursor-003.phpt
@@ -34,7 +34,7 @@ foreach ($c as $key => $record) {
 }
 ?>
 --EXPECTF--
-int(-1)
+int(0)
 array(2) {
   ["_id"]=>
   object(MongoId)#8 (1) {
@@ -44,7 +44,7 @@ array(2) {
   ["article_id"]=>
   int(0)
 }
-int(0)
+int(1)
 array(2) {
   ["_id"]=>
   object(MongoId)#9 (1) {
@@ -54,7 +54,7 @@ array(2) {
   ["article_id"]=>
   int(1)
 }
-int(1)
+int(2)
 array(2) {
   ["_id"]=>
   object(MongoId)#8 (1) {
@@ -64,7 +64,7 @@ array(2) {
   ["article_id"]=>
   int(2)
 }
-int(2)
+int(3)
 array(2) {
   ["_id"]=>
   object(MongoId)#%d (1) {
@@ -74,7 +74,7 @@ array(2) {
   ["article_id"]=>
   int(3)
 }
-int(3)
+int(4)
 array(2) {
   ["_id"]=>
   object(MongoId)#%d (1) {

--- a/tests/generic/mongocommandcursor-004.phpt
+++ b/tests/generic/mongocommandcursor-004.phpt
@@ -34,7 +34,7 @@ foreach ($c as $key => $record) {
 }
 ?>
 --EXPECTF--
-int(-1)
+int(0)
 array(2) {
   ["_id"]=>
   object(MongoId)#8 (1) {


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHP-1041

The first result document should have index 0, not -1.

---

This PR depends on #643, which is included in the branch, although it will be rebased accordingly.
