### PR TITLE
There is no retval to cleanup when exception is thrown

### DIFF
--- a/collection.c
+++ b/collection.c
@@ -1709,7 +1709,6 @@ static void mongo_collection_create_index_command(mongo_connection *connection, 
 	zval_ptr_dtor(&cmd);
  
 	if (EG(exception)) {
-		zval_ptr_dtor(&retval);
 		return;
 	}
 


### PR DESCRIPTION
We now correctly throw an exception, which means we don't return a zval, so there is no spoon to clenaup.
