### PR TITLE
Fixed PHP-1086: Inserting documents with WriteConcern during failover br...

### DIFF
--- a/collection.c
+++ b/collection.c
@@ -1103,7 +1103,6 @@ PHP_METHOD(MongoCollection, insert)
 	link = (mongoclient*)zend_object_store_get_object(c->link TSRMLS_CC);
 
 	if ((connection = get_server(c, MONGO_CON_FLAG_WRITE TSRMLS_CC)) == NULL) {
-		zend_clear_exception(TSRMLS_C);
 		RETURN_FALSE;
 	}
 


### PR DESCRIPTION
...oken

This is already covered by tests/replicaset-failover/mongocollection-insert-001.phpt
But as the failover testscases are so slow we only run them on Jenkins which is
why this wasn't discovered earlier

We don't actually support w=-1 (ignore socket errors) so we do want to throw exception
here in all cases
