### PR TITLE
Do not match exact byte sizes in maxWriteBatchSize tests

### DIFF
--- a/tests/standalone/mongoinsertbatch-003_32bit.phpt
+++ b/tests/standalone/mongoinsertbatch-003_32bit.phpt
@@ -42,28 +42,28 @@ array(4) {
     ["count"]=>
     int(1000)
     ["size"]=>
-    int(40997)
+    int(%d)
   }
   [1]=>
   array(2) {
     ["count"]=>
     int(1000)
     ["size"]=>
-    int(40997)
+    int(%d)
   }
   [2]=>
   array(2) {
     ["count"]=>
     int(1000)
     ["size"]=>
-    int(40997)
+    int(%d)
   }
   [3]=>
   array(2) {
     ["count"]=>
     int(1)
     ["size"]=>
-    int(146)
+    int(%d)
   }
 }
 int(0)

--- a/tests/standalone/mongoinsertbatch-003_64bit.phpt
+++ b/tests/standalone/mongoinsertbatch-003_64bit.phpt
@@ -42,28 +42,28 @@ array(4) {
     ["count"]=>
     int(1000)
     ["size"]=>
-    int(44991)
+    int(%d)
   }
   [1]=>
   array(2) {
     ["count"]=>
     int(1000)
     ["size"]=>
-    int(44991)
+    int(%d)
   }
   [2]=>
   array(2) {
     ["count"]=>
     int(1000)
     ["size"]=>
-    int(44991)
+    int(%d)
   }
   [3]=>
   array(2) {
     ["count"]=>
     int(1)
     ["size"]=>
-    int(144)
+    int(%d)
   }
 }
 int(0)


### PR DESCRIPTION
These tests care about the splitting of batches around the maxWriteBatchSize limit (i.e. 1000). They do not need to assert an exact value for the byte size of the serialized BSON.
