### PR TITLE
Lower socket timeout in PHP-1065 test

### DIFF
--- a/tests/standalone/bug01065.phpt
+++ b/tests/standalone/bug01065.phpt
@@ -5,50 +5,53 @@ Test for PHP-1065: Mongo driver is crashing during getmore
 <?php require_once "tests/utils/standalone.inc" ?>
 --FILE--
 <?php
+
 function log_getmore($server, $cursor_options)
 {
-    echo __METHOD__, "\n";
+    printf("%s\n", __METHOD__);
 }
 
-$ctx = stream_context_create(
-    array(
-        "mongodb" => array( "log_getmore" => "log_getmore",)
-    )
-);
+$ctx = stream_context_create(array(
+    "mongodb" => array("log_getmore" => "log_getmore")
+));
 
 require_once "tests/utils/server.inc";
 
 $host = MongoShellServer::getStandaloneInfo();
-$mc = new MongoClient($host . "/test?socketTimeoutMS=10", array(), array("context" => $ctx));
-$db = $mc->selectDb(dbname());
+$mc = new MongoClient($host, array(), array("context" => $ctx));
+
 $collection = $mc->selectCollection(dbname(), collname(__FILE__));
 $collection->drop();
 
-
-
-foreach(range(0, 8196) as $i) {
-    $collection->insert(array("document" => $i, uniqid("aggr") => uniqid(), "sum" => $i*10), array("w" => 0));
+for ($i = 0; $i < 10; ++$i) {
+    $collection->insert(array("x" => $i), array("w" => 0));
 }
 
-$pipeline = array(array(
-    '$match' => array("document" => array('$gt' => 3030)),
-));
+$cursor = $collection->find(array('$where' => 'sleep(1) || true'));
+$cursor->batchSize(2);
+$cursor->timeout(-1);
 
-$cursor = $collection->aggregateCursor($pipeline, array("cursor" => array("batchSize" => 0)));
-$x = 0;
+$document = $cursor->getNext();
+printf("First document: x = %d\n", $document['x']);
+
+$document = $cursor->getNext();
+printf("Second document: x = %d\n", $document['x']);
+
+$cursor->timeout(1);
+
 try {
-    foreach($cursor as $row) {
-        echo "TEST FAILED\n";
-    }
-    echo "The getmore should have timedout :( your system may have super powers?\n";
-} catch(Exception $e) {
+    $document = $cursor->getNext();
+    // getmore should time out within 1ms, so this should never be reached
+    echo "Expected getmore to time out but it did not!\n";
+} catch(MongoCursorTimeoutException $e) {
     echo $e->getMessage(), "\n";
 }
 ?>
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
+First document: x = 0
+Second document: x = 1
 log_getmore
 %s:%d: Read timed out after reading 0 bytes, waited for 0.%d seconds
 ===DONE===
-


### PR DESCRIPTION
@bjori: I attempted to use `0` for `socketTimeoutMS`, but it appeared to never time out. I was under the impression that `-1` meant "wait forever" and `0` would be an instantaneous time out.

Beyond that, I just cleaned up some of the other code in the test case. There was no need to insert 8000 documents with extra fields, so I toned that down to 1000 documents with a non-indexed field we can then query by.
