### PR TITLE
PHP-1158: Don't log connectTimeoutMS replacement when changing default

### DIFF
--- a/mcon/parse.c
+++ b/mcon/parse.c
@@ -380,10 +380,11 @@ int mongo_store_option(mongo_con_manager *manager, mongo_servers *servers, char 
 
 		mongo_manager_log(manager, MLOG_PARSE, MLOG_INFO, "- Found option 'connectTimeoutMS': %d", value);
 
-		if (servers->options.connectTimeoutMS != value) {
+		if (servers->options.connectTimeoutMS != MONGO_CONNECTION_DEFAULT_CONNECT_TIMEOUT) {
 			mongo_manager_log(manager, MLOG_PARSE, MLOG_WARN, "- Replacing previously set value for 'connectTimeoutMS' (%d)", servers->options.connectTimeoutMS);
-			servers->options.connectTimeoutMS = value;
 		}
+
+		servers->options.connectTimeoutMS = value;
 
 		return 0;
 	}
@@ -566,10 +567,11 @@ int mongo_store_option(mongo_con_manager *manager, mongo_servers *servers, char 
 
 		mongo_manager_log(manager, MLOG_PARSE, MLOG_INFO, "- Found option 'timeout' ('connectTimeoutMS'): %d", value);
 
-		if (servers->options.connectTimeoutMS != value) {
+		if (servers->options.connectTimeoutMS != MONGO_CONNECTION_DEFAULT_CONNECT_TIMEOUT) {
 			mongo_manager_log(manager, MLOG_PARSE, MLOG_WARN, "- Replacing previously set value for 'connectTimeoutMS' (%d)", servers->options.connectTimeoutMS);
-			servers->options.connectTimeoutMS = value;
 		}
+
+		servers->options.connectTimeoutMS = value;
 
 		return -1;
 	}

--- a/tests/generic/bug00683.phpt
+++ b/tests/generic/bug00683.phpt
@@ -30,26 +30,21 @@ $m = new MongoClient($dsn, array("connect" => false, "connecttimeoutms" => 7));
 --EXPECTF--
 timeout only
 - Found option 'timeout' ('connectTimeoutMS'): 1
-- Replacing previously set value for 'connectTimeoutMS' (60000)
 
 %s: MongoClient::__construct(): The 'timeout' option is deprecated. Please use 'connectTimeoutMS' instead in %s on line %d
 timeout and connectTimeoutMS
 - Found option 'timeout' ('connectTimeoutMS'): 2
-- Replacing previously set value for 'connectTimeoutMS' (60000)
 
 %s: MongoClient::__construct(): The 'timeout' option is deprecated. Please use 'connectTimeoutMS' instead in %s on line %d
 - Found option 'connectTimeoutMS': 3
 - Replacing previously set value for 'connectTimeoutMS' (2)
 connectTimeoutMS only
 - Found option 'connectTimeoutMS': 4
-- Replacing previously set value for 'connectTimeoutMS' (60000)
 connectTimeoutMS and timeout
 - Found option 'connectTimeoutMS': 5
-- Replacing previously set value for 'connectTimeoutMS' (60000)
 - Found option 'timeout' ('connectTimeoutMS'): 6
 - Replacing previously set value for 'connectTimeoutMS' (5)
 
 %s: MongoClient::__construct(): The 'timeout' option is deprecated. Please use 'connectTimeoutMS' instead in %s on line %d
 connecttimeoutms lowercased
 - Found option 'connectTimeoutMS': 7
-- Replacing previously set value for 'connectTimeoutMS' (60000)

--- a/tests/replicaset/legacy/log-1.phpt
+++ b/tests/replicaset/legacy/log-1.phpt
@@ -29,7 +29,6 @@ PARSE   INFO: - Connection type: STANDALONE
 PARSE   INFO: - Found option 'replicaSet': '%s'
 PARSE   INFO: - Switching connection type: REPLSET
 PARSE   INFO: - Found option 'connectTimeoutMS': 30000
-PARSE   WARN: - Replacing previously set value for 'connectTimeoutMS' (60000)
 CON     INFO: mongo_get_read_write_connection: finding a REPLSET connection (read)
 CON     INFO: connection_create: creating new connection for %s:%d
 CON     FINE: Connecting to tcp://%s:%d (%s:%d;%s;.;%d) with connection timeout: 30.000000

--- a/tests/replicaset/legacy/log-1_alternative.phpt
+++ b/tests/replicaset/legacy/log-1_alternative.phpt
@@ -29,7 +29,6 @@ PARSE   INFO: - Connection type: %s
 PARSE   INFO: - Found option 'replicaSet': 'REPLICASET'
 PARSE   INFO: - Switching connection type: %s
 PARSE   INFO: - Found option 'connectTimeoutMS': 30000
-PARSE   WARN: - Replacing previously set value for 'connectTimeoutMS' (60000)
 CON     INFO: mongo_get_read_write_connection: finding a REPLSET connection (read)
 CON     INFO: connection_create: creating new connection for %s:%d
 CON     FINE: Connecting to tcp://%s:%d (%s:%d;%s;.;%d) with connection timeout: 30.000000

--- a/tests/standalone/bug01158.phpt
+++ b/tests/standalone/bug01158.phpt
@@ -1,0 +1,78 @@
+--TEST--
+Test for PHP-1158: Driver emits warning after setting connectTimeoutMS
+--SKIPIF--
+<?php require_once "tests/utils/standalone.inc" ?>
+<?php if (!version_compare(phpversion(), "5.3", '>=')) echo "skip >= PHP 5.3 needed\n"; ?>
+--FILE--
+<?php
+require_once "tests/utils/server.inc";
+
+printLogs(MongoLog::PARSE, MongoLog::ALL, "/Found option|Replacing/");
+
+$host = MongoShellServer::getStandaloneInfo();
+
+echo "connectTimeoutMS in query string\n";
+new MongoClient(sprintf('mongodb://%s/?connectTimeoutMS=1', $host));
+
+echo "\nconnectTimeoutMS in options array\n";
+new MongoClient($host, array('connectTimeoutMS' => 1));
+
+echo "\nconnectTimeoutMS in query string and options array\n";
+new MongoClient(sprintf('mongodb://%s/?connectTimeoutMS=1', $host), array('connectTimeoutMS' => 2));
+
+echo "\ntimeout in query string\n";
+new MongoClient(sprintf('mongodb://%s/?timeout=1', $host));
+
+echo "\ntimeout in options array\n";
+new MongoClient($host, array('timeout' => 1));
+
+echo "\ntimeout in query string and options array\n";
+new MongoClient(sprintf('mongodb://%s/?timeout=1', $host), array('timeout' => 2));
+
+echo "\nconnectTimeoutMS and timeout in query string and options array\n";
+new MongoClient(
+    sprintf('mongodb://%s/?connectTimeoutMS=1&timeout=2', $host),
+    array('connectTimeoutMS' => 3, 'timeout' => 4)
+);
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+connectTimeoutMS in query string
+- Found option 'connectTimeoutMS': 1
+
+connectTimeoutMS in options array
+- Found option 'connectTimeoutMS': 1
+
+connectTimeoutMS in query string and options array
+- Found option 'connectTimeoutMS': 1
+- Found option 'connectTimeoutMS': 2
+- Replacing previously set value for 'connectTimeoutMS' (1)
+
+timeout in query string
+- Found option 'timeout' ('connectTimeoutMS'): 1
+
+timeout in options array
+- Found option 'timeout' ('connectTimeoutMS'): 1
+
+Deprecated: MongoClient::__construct(): The 'timeout' option is deprecated. Please use 'connectTimeoutMS' instead in %s on line %d
+
+timeout in query string and options array
+- Found option 'timeout' ('connectTimeoutMS'): 1
+- Found option 'timeout' ('connectTimeoutMS'): 2
+- Replacing previously set value for 'connectTimeoutMS' (1)
+
+Deprecated: MongoClient::__construct(): The 'timeout' option is deprecated. Please use 'connectTimeoutMS' instead in %s on line %d
+
+connectTimeoutMS and timeout in query string and options array
+- Found option 'connectTimeoutMS': 1
+- Found option 'timeout' ('connectTimeoutMS'): 2
+- Replacing previously set value for 'connectTimeoutMS' (1)
+- Found option 'connectTimeoutMS': 3
+- Replacing previously set value for 'connectTimeoutMS' (2)
+- Found option 'timeout' ('connectTimeoutMS'): 4
+- Replacing previously set value for 'connectTimeoutMS' (3)
+
+Deprecated: MongoClient::__construct(): The 'timeout' option is deprecated. Please use 'connectTimeoutMS' instead in %s on line %d
+===DONE===

--- a/tests/standalone/legacy/log-1.phpt
+++ b/tests/standalone/legacy/log-1.phpt
@@ -25,7 +25,6 @@ PARSE   INFO: Parsing mongodb://127.0.0.1:30000
 PARSE   INFO: - Found node: 127.0.0.1:30000
 PARSE   INFO: - Connection type: %s
 PARSE   INFO: - Found option 'connectTimeoutMS': 30000
-PARSE   WARN: - Replacing previously set value for 'connectTimeoutMS' (60000)
 CON     INFO: mongo_get_read_write_connection: finding a STANDALONE connection
 CON     INFO: connection_create: creating new connection for 127.0.0.1:30000
 CON     FINE: Connecting to tcp://127.0.0.1:30000 (127.0.0.1:30000;-;.;%d) with connection timeout: 30.000000


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHP-1158
