### PR TITLE
Fix incomplete MongoLog messages for MongoCursor timeout

### DIFF
--- a/cursor.c
+++ b/cursor.c
@@ -196,12 +196,12 @@ PHP_METHOD(MongoCursor, __construct)
 	/* The value hasn't been modified from what we registered it as originally */
 	if (Z_LVAL_P(timeout) == PHP_MONGO_STATIC_CURSOR_TIMEOUT_NOT_SET_INITIALIZER) {
 		cursor->timeout = link->servers->options.socketTimeoutMS;
-		mongo_manager_log(link->manager, MLOG_CON, MLOG_FINE, "Using %d from default with", cursor->timeout);
+		mongo_manager_log(link->manager, MLOG_CON, MLOG_FINE, "Initializing cursor timeout to %d (from connection options)", cursor->timeout);
 	} else {
 		cursor->timeout = Z_LVAL_P(timeout);
 		/* The value was modified, bad user, bad user! Tell him its deprecated */
 		php_error_docref(NULL TSRMLS_CC, MONGO_E_DEPRECATED, "The 'MongoCursor::$timeout' static property is deprecated, please call MongoCursor->timeout() instead");
-		mongo_manager_log(link->manager, MLOG_CON, MLOG_FINE, "Using %d from deprecated with", cursor->timeout);
+		mongo_manager_log(link->manager, MLOG_CON, MLOG_FINE, "Initializing cursor timeout to %d (from deprecated static property)", cursor->timeout);
 	}
 
 

--- a/tests/auth-standalone/bug01107-1.phpt
+++ b/tests/auth-standalone/bug01107-1.phpt
@@ -60,6 +60,7 @@ Now setting stream timeout back to 30.987000
 Setting the stream timeout to 1.234000
 Now setting stream timeout back to 30.987000
 Dummy query
+Initializing cursor timeout to 30987 (from connection options)
 No timeout changes for %s:%d;-;%s;%d
 No timeout changes for %s:%d;-;%s;%d
 I'm alive

--- a/tests/auth-standalone/bug01107-2.phpt
+++ b/tests/auth-standalone/bug01107-2.phpt
@@ -58,6 +58,7 @@ Now setting stream timeout back to 30.000000
 Setting the stream timeout to 60.000000
 Now setting stream timeout back to 30.000000
 Dummy query
+Initializing cursor timeout to 30000 (from connection options)
 No timeout changes for %s:%d;-;%s;%d
 No timeout changes for %s:%d;-;%s;%d
 I'm alive

--- a/tests/standalone/bug01099-1.phpt
+++ b/tests/standalone/bug01099-1.phpt
@@ -17,15 +17,17 @@ $host = MongoShellServer::getStandaloneInfo();
 $dsn = "mongodb://$host/?socketTimeoutMS=-1&connectTimeoutMS=-1";
 $mc = new MongoClient($dsn);
 echo "Connected\n";
+
 $db = $mc->selectDb(dbname());
 $collection = $mc->selectCollection(dbname(), collname(__FILE__));
 $collection->drop();
+echo "Dropped\n";
 
 $cursor = $collection->findOne();
 echo "findOne done\n";
-$cursor = $collection->find();
 
 echo "\n\nTimeout 20\n";
+$cursor = $collection->find();
 $cursor->timeout(20);
 iterator_to_array($cursor);
 
@@ -52,14 +54,18 @@ No timeout changes for %s:%d;-;.;%d
 No timeout changes for %s:%d;-;.;%d
 No timeout changes for %s:%d;-;.;%d
 Connected
+Initializing cursor timeout to -1 (from connection options)
 No timeout changes for %s:%d;-;.;%d
 No timeout changes for %s:%d;-;.;%d
+Dropped
+Initializing cursor timeout to -1 (from connection options)
 No timeout changes for %s:%d;-;.;%d
 No timeout changes for %s:%d;-;.;%d
 findOne done
 
 
 Timeout 20
+Initializing cursor timeout to -1 (from connection options)
 Setting the stream timeout to 0.020000
 Now setting stream timeout back to -1.000000
 Setting the stream timeout to 0.020000
@@ -69,6 +75,7 @@ Now setting stream timeout back to -1.000000
 Timeout 42
 
 %s: The 'MongoCursor::$timeout' static property is deprecated, please call MongoCursor->timeout() instead in %s on line %d
+Initializing cursor timeout to 42 (from deprecated static property)
 Setting the stream timeout to 0.042000
 Now setting stream timeout back to -1.000000
 Setting the stream timeout to 0.042000
@@ -78,6 +85,7 @@ Now setting stream timeout back to -1.000000
 Timeout -1
 
 %s: The 'MongoCursor::$timeout' static property is deprecated, please call MongoCursor->timeout() instead in %s on line %d
+Initializing cursor timeout to 42 (from deprecated static property)
 No timeout changes for %s:%d;-;.;%d
 No timeout changes for %s:%d;-;.;%d
 ===DONE===

--- a/tests/standalone/bug01099-2.phpt
+++ b/tests/standalone/bug01099-2.phpt
@@ -17,15 +17,17 @@ $host = MongoShellServer::getStandaloneInfo();
 $dsn = "mongodb://$host/?socketTimeoutMS=42";
 $mc = new MongoClient($dsn);
 echo "Connected\n";
+
 $db = $mc->selectDb(dbname());
 $collection = $mc->selectCollection(dbname(), collname(__FILE__));
 $collection->drop();
+echo "Dropped\n";
 
 $cursor = $collection->findOne();
 echo "findOne done\n";
-$cursor = $collection->find();
 
 echo "\n\nTimeout 20\n";
+$cursor = $collection->find();
 $cursor->timeout(20);
 iterator_to_array($cursor);
 
@@ -63,14 +65,18 @@ Now setting stream timeout back to 0.042000
 Setting the stream timeout to 60.000000
 Now setting stream timeout back to 0.042000
 Connected
+Initializing cursor timeout to 42 (from connection options)
 No timeout changes for %s:%d;-;.;%d
 No timeout changes for %s:%d;-;.;%d
+Dropped
+Initializing cursor timeout to 42 (from connection options)
 No timeout changes for %s:%d;-;.;%d
 No timeout changes for %s:%d;-;.;%d
 findOne done
 
 
 Timeout 20
+Initializing cursor timeout to 42 (from connection options)
 Setting the stream timeout to 0.020000
 Now setting stream timeout back to 0.042000
 Setting the stream timeout to 0.020000
@@ -80,6 +86,7 @@ Now setting stream timeout back to 0.042000
 Timeout 43
 
 %s: The 'MongoCursor::$timeout' static property is deprecated, please call MongoCursor->timeout() instead in %s on line %d
+Initializing cursor timeout to 43 (from deprecated static property)
 Setting the stream timeout to 0.043000
 Now setting stream timeout back to 0.042000
 Setting the stream timeout to 0.043000
@@ -89,6 +96,7 @@ Now setting stream timeout back to 0.042000
 Timeout -1
 
 %s: The 'MongoCursor::$timeout' static property is deprecated, please call MongoCursor->timeout() instead in %s on line %d
+Initializing cursor timeout to 43 (from deprecated static property)
 Setting the stream timeout to -1.000000
 Now setting stream timeout back to 0.042000
 Setting the stream timeout to -1.000000
@@ -98,6 +106,7 @@ Now setting stream timeout back to 0.042000
 Timeout 42
 
 %s: The 'MongoCursor::$timeout' static property is deprecated, please call MongoCursor->timeout() instead in %s on line %d
+Initializing cursor timeout to 43 (from deprecated static property)
 No timeout changes for %s:%d;-;.;%d
 No timeout changes for %s:%d;-;.;%d
 ===DONE===

--- a/tests/standalone/bug01099-3.phpt
+++ b/tests/standalone/bug01099-3.phpt
@@ -17,15 +17,17 @@ $host = MongoShellServer::getStandaloneInfo();
 $dsn = "mongodb://$host/";
 $mc = new MongoClient($dsn);
 echo "Connected\n";
+
 $db = $mc->selectDb(dbname());
 $collection = $mc->selectCollection(dbname(), collname(__FILE__));
 $collection->drop();
+echo "Dropped\n";
 
 $cursor = $collection->findOne();
 echo "findOne done\n";
-$cursor = $collection->find();
 
 echo "\n\nTimeout 20\n";
+$cursor = $collection->find();
 $cursor->timeout(20);
 iterator_to_array($cursor);
 
@@ -63,14 +65,18 @@ Now setting stream timeout back to 30.000000
 Setting the stream timeout to 60.000000
 Now setting stream timeout back to 30.000000
 Connected
+Initializing cursor timeout to 30000 (from connection options)
 No timeout changes for %s:%d;-;.;%d
 No timeout changes for %s:%d;-;.;%d
+Dropped
+Initializing cursor timeout to 30000 (from connection options)
 No timeout changes for %s:%d;-;.;%d
 No timeout changes for %s:%d;-;.;%d
 findOne done
 
 
 Timeout 20
+Initializing cursor timeout to 30000 (from connection options)
 Setting the stream timeout to 0.020000
 Now setting stream timeout back to 30.000000
 Setting the stream timeout to 0.020000
@@ -80,6 +86,7 @@ Now setting stream timeout back to 30.000000
 Timeout 43
 
 %s: The 'MongoCursor::$timeout' static property is deprecated, please call MongoCursor->timeout() instead in %s on line %d
+Initializing cursor timeout to 43 (from deprecated static property)
 Setting the stream timeout to 0.043000
 Now setting stream timeout back to 30.000000
 Setting the stream timeout to 0.043000
@@ -89,6 +96,7 @@ Now setting stream timeout back to 30.000000
 Timeout -1
 
 %s: The 'MongoCursor::$timeout' static property is deprecated, please call MongoCursor->timeout() instead in %s on line %d
+Initializing cursor timeout to 43 (from deprecated static property)
 Setting the stream timeout to -1.000000
 Now setting stream timeout back to 30.000000
 Setting the stream timeout to -1.000000
@@ -98,6 +106,7 @@ Now setting stream timeout back to 30.000000
 Timeout 42
 
 %s: The 'MongoCursor::$timeout' static property is deprecated, please call MongoCursor->timeout() instead in %s on line %d
+Initializing cursor timeout to 43 (from deprecated static property)
 Setting the stream timeout to 0.042000
 Now setting stream timeout back to 30.000000
 Setting the stream timeout to 0.042000

--- a/tests/standalone/bug01155-1.phpt
+++ b/tests/standalone/bug01155-1.phpt
@@ -46,14 +46,17 @@ No timeout changes for %s:%d;-;.;%d
 Connected
 
 Dropping collection
+Initializing cursor timeout to 0 (from connection options)
 No timeout changes for %s:%d;-;.;%d
 No timeout changes for %s:%d;-;.;%d
 
 Executing find() with default timeout
+Initializing cursor timeout to 0 (from connection options)
 No timeout changes for %s:%d;-;.;%d
 No timeout changes for %s:%d;-;.;%d
 
 Executing find() with MongoCursor::timeout(): 1000
+Initializing cursor timeout to 0 (from connection options)
 Setting the stream timeout to 1.000000
 Stream timeout will be reverted to default_socket_timeout (60)
 Now setting stream timeout back to 60.000000
@@ -64,6 +67,7 @@ Now setting stream timeout back to 60.000000
 Executing find() with MongoCursor::$timeout: 1000
 
 %s: The 'MongoCursor::$timeout' static property is deprecated, please call MongoCursor->timeout() instead in %s on line %d
+Initializing cursor timeout to 1000 (from deprecated static property)
 Setting the stream timeout to 1.000000
 Stream timeout will be reverted to default_socket_timeout (60)
 Now setting stream timeout back to 60.000000

--- a/tests/standalone/bug01155-3.phpt
+++ b/tests/standalone/bug01155-3.phpt
@@ -63,20 +63,24 @@ Now setting stream timeout back to -1.000000
 Connected
 
 Dropping collection
+Initializing cursor timeout to -1 (from connection options)
 No timeout changes for %s:%d;-;.;%d
 No timeout changes for %s:%d;-;.;%d
 
 Executing find() with default timeout
+Initializing cursor timeout to -1 (from connection options)
 No timeout changes for %s:%d;-;.;%d
 No timeout changes for %s:%d;-;.;%d
 
 Executing find() with MongoCursor::timeout(): -2
+Initializing cursor timeout to -1 (from connection options)
 No timeout changes for %s:%d;-;.;%d
 No timeout changes for %s:%d;-;.;%d
 
 Executing find() with MongoCursor::$timeout: -3
 
 %s: The 'MongoCursor::$timeout' static property is deprecated, please call MongoCursor->timeout() instead in %s on line %d
+Initializing cursor timeout to -3 (from deprecated static property)
 No timeout changes for %s:%d;-;.;%d
 No timeout changes for %s:%d;-;.;%d
 ===DONE===

--- a/tests/standalone/bug01156-1.phpt
+++ b/tests/standalone/bug01156-1.phpt
@@ -47,14 +47,17 @@ No timeout changes for %s:%d;-;.;%d
 Connected
 
 Dropping collection
+Initializing cursor timeout to 0 (from connection options)
 No timeout changes for %s:%d;-;.;%d
 No timeout changes for %s:%d;-;.;%d
 
 Executing find() with default timeout
+Initializing cursor timeout to 0 (from connection options)
 No timeout changes for %s:%d;-;.;%d
 No timeout changes for %s:%d;-;.;%d
 
 Executing find() with MongoCursor::timeout(): 4321
+Initializing cursor timeout to 0 (from connection options)
 Setting the stream timeout to 4.321000
 Stream timeout will be reverted to default_socket_timeout (20)
 Now setting stream timeout back to 20.000000

--- a/tests/standalone/bug01156-2.phpt
+++ b/tests/standalone/bug01156-2.phpt
@@ -54,6 +54,7 @@ No timeout changes for %s:%d;-;.;%d
 Connected
 
 Dropping collection
+Initializing cursor timeout to 0 (from connection options)
 No timeout changes for %s:%d;-;.;%d
 No timeout changes for %s:%d;-;.;%d
 
@@ -62,6 +63,7 @@ No timeout changes for %s:%d;-;.;%d
 No timeout changes for %s:%d;-;.;%d
 
 Executing find() with 4-second sleep and no timeout
+Initializing cursor timeout to 0 (from connection options)
 Setting the stream timeout to -1.000000
 Stream timeout will be reverted to default_socket_timeout (1)
 Now setting stream timeout back to 1.000000
@@ -70,6 +72,7 @@ Stream timeout will be reverted to default_socket_timeout (1)
 Now setting stream timeout back to 1.000000
 
 Executing find() with 4-second sleep and default timeout
+Initializing cursor timeout to 0 (from connection options)
 No timeout changes for %s:%d;-;.;%d
 find() timed out as expected
 ===DONE===


### PR DESCRIPTION
See: ce20cdcf54c0bc2717913e3737c476f5d5f155f2
