### PR TITLE
PHP-904 Implement MongoDate::__set_state

### DIFF
--- a/tests/no-servers/mongodate-008.phpt
+++ b/tests/no-servers/mongodate-008.phpt
@@ -1,0 +1,27 @@
+--TEST--
+MongoDate works with var_export()
+--SKIPIF--
+<?php require_once dirname(__FILE__) . "/skipif.inc"; ?>
+--FILE--
+<?php
+$date = new MongoDate(12345, 67890);
+var_export($date);
+echo "\n";
+
+$exported = MongoDate::__set_state(array(
+   'sec' => '12345',
+   'usec' => '67000',
+));
+var_dump($exported);
+?>
+--EXPECT--
+MongoDate::__set_state(array(
+   'sec' => 12345,
+   'usec' => 67000,
+))
+object(MongoDate)#2 (2) {
+  ["sec"]=>
+  int(12345)
+  ["usec"]=>
+  int(67000)
+}

--- a/types/date.c
+++ b/types/date.c
@@ -109,10 +109,36 @@ PHP_METHOD(MongoDate, __toString)
 }
 /* }}} */
 
+/* {{{ MongoDate::__set_state()
+ */
+PHP_METHOD(MongoDate, __set_state)
+{
+	zval *state, **sec, **usec;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "a", &state) == FAILURE) {
+		return;
+	}
+
+	if (zend_hash_find(HASH_P(state), "sec", strlen("sec") + 1, (void**) &sec) == FAILURE) {
+		return;
+	}
+
+	if (zend_hash_find(HASH_P(state), "usec", strlen("usec") + 1, (void**) &usec) == FAILURE) {
+		return;
+	}
+
+	convert_to_long(*sec);
+	convert_to_long(*usec);
+	object_init_ex(return_value, mongo_ce_Date);
+	php_mongo_mongodate_populate(return_value, Z_LVAL_PP(sec), Z_LVAL_PP(usec) TSRMLS_CC);
+}
+/* }}} */
+
 
 static zend_function_entry MongoDate_methods[] = {
 	PHP_ME(MongoDate, __construct, NULL, ZEND_ACC_PUBLIC)
 	PHP_ME(MongoDate, __toString, NULL, ZEND_ACC_PUBLIC)
+	PHP_ME(MongoDate, __set_state, NULL, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	PHP_FE_END
 };
 

--- a/types/date.h
+++ b/types/date.h
@@ -18,6 +18,7 @@
 
 PHP_METHOD(MongoDate, __construct);
 PHP_METHOD(MongoDate, __toString);
+PHP_METHOD(MongoDate, __set_state);
 void php_mongo_mongodate_populate(zval *mongocode_object, long sec, long usec TSRMLS_DC);
 void php_mongo_mongodate_make_now(long *sec, long *usec);
 


### PR DESCRIPTION
Fixes PHP-904
https://jira.mongodb.org/browse/PHP-904

Allows MongoDate objects exported via var_export() to be parsed.
var_export() is handy when creating test fixtures.

This is my first time contributing to any php extension. I think I got it right, but happy to fix anything or resubmit against a different branch. Thanks!
