### PR TITLE
PHP-1249: MongoCursor::count() should use cursor's socket timeout

### DIFF
--- a/cursor.c
+++ b/cursor.c
@@ -1028,7 +1028,7 @@ PHP_METHOD(MongoCursor, reset)
 PHP_METHOD(MongoCursor, count)
 {
 	zend_bool all = 0;
-	zval *response, *cmd, **n;
+	zval *response, *cmd, *options, **n;
 	mongo_cursor *cursor;
 	mongoclient *link;
 	char *cname, *dbname;
@@ -1063,8 +1063,13 @@ PHP_METHOD(MongoCursor, count)
 		add_assoc_long(cmd, "skip", cursor->skip);
 	}
 
-	response = php_mongo_runcommand(cursor->zmongoclient, &cursor->read_pref, dbname, strlen(dbname), cmd, NULL, 0, NULL TSRMLS_CC);
+	MAKE_STD_ZVAL(options);
+	array_init(options);
+	add_assoc_long(options, "socketTimeoutMS", cursor->timeout);
+
+	response = php_mongo_runcommand(cursor->zmongoclient, &cursor->read_pref, dbname, strlen(dbname), cmd, options, 0, NULL TSRMLS_CC);
 	zval_ptr_dtor(&cmd);
+	zval_ptr_dtor(&options);
 	efree(dbname);
 
 	if (!response) {

--- a/tests/generic/mongocursor-count-001.phpt
+++ b/tests/generic/mongocursor-count-001.phpt
@@ -1,0 +1,42 @@
+--TEST--
+MongoCursor::count() inherits socket timeout from cursor
+--SKIPIF--
+<?php if (version_compare(phpversion(), "5.3.0", "lt")) exit("skip setCallback and closures are 5.3+"); ?>
+<?php if (!MONGO_STREAMS) { echo "skip This test requires streams support"; } ?>
+<?php require_once "tests/utils/standalone.inc"; ?>
+--FILE--
+<?php require_once "tests/utils/server.inc"; ?>
+<?php
+
+$host = MongoShellServer::getStandaloneInfo();
+$m = new MongoClient($host);
+$c = $m->selectCollection(dbname(), collname(__FILE__));
+
+$c->drop();
+$c->insert(array('x' => 1));
+$c->insert(array('x' => 2));
+$c->insert(array('x' => 3));
+$c->insert(array('x' => 4));
+
+printLogs(MongoLog::ALL, MongoLog::ALL, "/timeout/i");
+
+printf("Count all documents, default timeout: %d\n", $c->find()->count());
+echo "\n";
+printf("Count all documents, timeout = 1000: %d\n", $c->find()->timeout(1000)->count());
+?>
+===DONE===
+--EXPECTF--
+Initializing cursor timeout to 30000 (from connection options)
+Initializing cursor timeout to 30000 (from connection options)
+No timeout changes for %s:%d;-;%s;%d
+No timeout changes for %s:%d;-;%s;%d
+Count all documents, default timeout: 4
+
+Initializing cursor timeout to 30000 (from connection options)
+Initializing cursor timeout to 30000 (from connection options)
+Setting the stream timeout to 1.000000
+Now setting stream timeout back to 30.000000
+Setting the stream timeout to 1.000000
+Now setting stream timeout back to 30.000000
+Count all documents, timeout = 1000: 4
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHP-1249
