### PR TITLE
PHP-1251: MongoCursor::count() should use cursor's maxTimeMS

### DIFF
--- a/cursor.c
+++ b/cursor.c
@@ -1065,7 +1065,7 @@ PHP_METHOD(MongoCursor, count)
 
 	if (cursor->query) {
 		if (cursor->special) {
-			zval **query = NULL, **hint = NULL;
+			zval **query = NULL, **hint = NULL, **maxTimeMS = NULL;
 
 			if (zend_hash_find(HASH_P(cursor->query), ZEND_STRS("$query"), (void**)&query) == SUCCESS) {
 				/* If the query hash is empty, don't include it in the count. as
@@ -1080,6 +1080,9 @@ PHP_METHOD(MongoCursor, count)
 			if (zend_hash_find(HASH_P(cursor->query), ZEND_STRS("$hint"), (void**)&hint) == SUCCESS) {
 				add_assoc_zval(cmd, "hint", *hint);
 				zval_add_ref(hint);
+			}
+			if (zend_hash_find(HASH_P(cursor->query), ZEND_STRS("$maxTimeMS"), (void**)&maxTimeMS) == SUCCESS) {
+				add_assoc_long(cmd, "maxTimeMS", Z_LVAL_PP(maxTimeMS));
 			}
 		} else {
 			if (zend_hash_num_elements(HASH_P(cursor->query)) > 0) {

--- a/tests/generic/mongocursor-count-005.phpt
+++ b/tests/generic/mongocursor-count-005.phpt
@@ -1,0 +1,45 @@
+--TEST--
+MongoCursor::count() with maxTimeMS option
+--SKIPIF--
+<?php $needs = "2.6.0"; require_once "tests/utils/standalone.inc";?>
+<?php require_once "tests/utils/standalone.inc"; ?>
+--FILE--
+<?php require_once "tests/utils/server.inc"; ?>
+<?php
+
+function log_query($server, $query, $info) {
+    if (key($query) !== 'count') {
+        return;
+    }
+    printf("Count maxTimeMS: %s\n", array_key_exists('maxTimeMS', $query) ? $query['maxTimeMS'] : 'none');
+}
+
+$ctx = stream_context_create(array(
+    'mongodb' => array(
+        'log_query' => 'log_query',
+    ),
+));
+
+$host = MongoShellServer::getStandaloneInfo();
+$m = new MongoClient($host, array(), array('context' => $ctx));
+$c = $m->selectCollection(dbname(), collname(__FILE__));
+$c->drop();
+
+$c->insert(array('x' => 1));
+$c->insert(array('x' => 2, 'y' => 2));
+$c->insert(array('x' => 3, 'y' => 3));
+$c->insert(array('x' => 4));
+
+printf("Count documents, no maxTimeMS: %d\n", $c->find()->count());
+echo "\n";
+printf("Count documents, maxTimeMS = 1000: %d\n", $c->find()->maxTimeMS(1000)->count());
+
+?>
+===DONE===
+--EXPECT--
+Count maxTimeMS: none
+Count documents, no maxTimeMS: 4
+
+Count maxTimeMS: 1000
+Count documents, maxTimeMS = 1000: 4
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHP-1251

Currently based on #744, since the change is closely tied to `MongoCursor::count()` modifications from that PR. Only the final commit is necessary to review here. This PR will be rebased once #744 is merged.
