### PR TITLE
PHP-1263: Throw timeout exception for MongoCollection::count() maxTimeMS timeout

### DIFF
--- a/tests/auth-replicaset/bug00779.phpt
+++ b/tests/auth-replicaset/bug00779.phpt
@@ -110,8 +110,8 @@ int(13435)
 
 Testing primary count
 Bit 2 (SlaveOk) is not set
-string(%d) "Cannot run command count(): not master"
-int(20)
+string(%d) "%s:%d: not master"
+int(2)
 
 ----
 

--- a/tests/generic/mongocollection-count-004.phpt
+++ b/tests/generic/mongocollection-count-004.phpt
@@ -1,0 +1,35 @@
+--TEST--
+MongoCollection::count() supports maxTimeMS option
+--SKIPIF--
+<?php $needs = "2.6.0"; require_once "tests/utils/standalone.inc";?>
+--FILE--
+<?php require_once "tests/utils/server.inc"; ?>
+<?php
+
+$host = MongoShellServer::getStandaloneInfo();
+$mc = new MongoClient($host);
+
+configureFailPoint($mc, 'maxTimeAlwaysTimeOut', 1);
+
+$c = $mc->selectCollection(dbname(), collname(__FILE__));
+$c->drop();
+
+$c->insert(array('x' => 1));
+
+try {
+    $count = $c->count(array(), array('maxTimeMS' => 1000));
+    printf("Found %d documents\n", $count);
+} catch (Exception $e) {
+    printf("exception class: %s\n", get_class($e));
+    printf("exception message: %s\n", $e->getMessage());
+    printf("exception code: %d\n", $e->getCode());
+}
+
+?>
+===DONE===
+--EXPECTF--
+Configured maxTimeAlwaysTimeOut fail point
+exception class: MongoExecutionTimeoutException
+exception message: %s:%d: operation exceeded time limit
+exception code: 50
+===DONE===

--- a/tests/replicaset/bug00779.phpt
+++ b/tests/replicaset/bug00779.phpt
@@ -101,8 +101,8 @@ int(13435)
 
 Testing primary count
 Bit 2 (SlaveOk) is not set
-string(%d) "Cannot run command count(): not master"
-int(20)
+string(%d) "%s:%d: not master"
+int(2)
 
 ----
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHP-1263

---

Previously, the `count()` helper threw its own exceptions instead of utilizing `php_mongo_trigger_error_on_command_failure()`. With this change, MongoExecutionTimeoutException will now be thrown for a maxTimeMS timeout and other exceptions will be handled consistently with other command helpers that use the utility function.

`count()` may still throw its own exception, but only if the "n" field is not found in the response, which should never happen in practice. To be consistent with other command helpers, it now throws a MongoResultException for that error (not a BC break since it sub-classes MongoException).
