### PR TITLE
PHP-1264: Rename php_mongo_write_item fields

### DIFF
--- a/api/write.c
+++ b/api/write.c
@@ -273,15 +273,15 @@ int php_mongo_api_write_add(mongo_buffer *buf, int n, php_mongo_write_item *item
 
 	switch (item->type) {
 		case MONGODB_API_COMMAND_INSERT:
-			retval = php_mongo_api_insert_add(buf, n, item->write.insert, max_document_size TSRMLS_CC);
+			retval = php_mongo_api_insert_add(buf, n, item->write.insert_doc, max_document_size TSRMLS_CC);
 			break;
 
 		case MONGODB_API_COMMAND_UPDATE:
-			retval = php_mongo_api_update_add(buf, n, item->write.update, max_document_size TSRMLS_CC);
+			retval = php_mongo_api_update_add(buf, n, item->write.update_args, max_document_size TSRMLS_CC);
 			break;
 
 		case MONGODB_API_COMMAND_DELETE:
-			retval = php_mongo_api_delete_add(buf, n, item->write.delete, max_document_size TSRMLS_CC);
+			retval = php_mongo_api_delete_add(buf, n, item->write.delete_args, max_document_size TSRMLS_CC);
 			break;
 	}
 

--- a/api/write.h
+++ b/api/write.h
@@ -50,9 +50,9 @@ typedef enum {
 typedef struct {
 	php_mongo_write_types type;
 	union {
-		HashTable *insert;
-		php_mongo_write_update_args *update;
-		php_mongo_write_delete_args *delete;
+		HashTable *insert_doc;
+		php_mongo_write_update_args *update_args;
+		php_mongo_write_delete_args *delete_args;
 	} write;
 } php_mongo_write_item;
 

--- a/batch/write.c
+++ b/batch/write.c
@@ -149,7 +149,7 @@ PHP_METHOD(MongoWriteBatch, add)
 	write_item.type = intern->batch_type;
 	switch (intern->batch_type) {
 		case MONGODB_API_COMMAND_INSERT:
-			write_item.write.insert = ht_item;
+			write_item.write.insert_doc = ht_item;
 			break;
 
 		case MONGODB_API_COMMAND_UPDATE: {
@@ -180,7 +180,7 @@ PHP_METHOD(MongoWriteBatch, add)
 				update_args.upsert = Z_BVAL_PP(upsert);
 			}
 
-			write_item.write.update = &update_args;
+			write_item.write.update_args = &update_args;
 			break;
 		 }
 
@@ -202,7 +202,7 @@ PHP_METHOD(MongoWriteBatch, add)
 			delete_args.query = *q;
 			delete_args.limit = Z_LVAL_PP(limit);
 
-			write_item.write.delete = &delete_args;
+			write_item.write.delete_args = &delete_args;
 			break;
 		 }
 


### PR DESCRIPTION
Making the field names a bit more descriptive avoids use of "delete", which is a reserved word in C++.

---

https://jira.mongodb.org/browse/PHP-1264
