### PR TITLE
PHP-1276: Duplicate Key error message changed

### DIFF
--- a/tests/generic/bug00320-2.phpt
+++ b/tests/generic/bug00320-2.phpt
@@ -52,9 +52,9 @@ $m = new_mongo_standalone("phpunit");
 # Saving files to GridFS
 ######################################
 [Saved file] New file id:file0
-error message: Could not store file: %s:%d:%sE11000 duplicate key error index: phpunit.fs.files.$filename_1%Sdup key: { : "/tmp/GridFS_test.txt" }
+error message: Could not store file: %s:%d:%s { : "/tmp/GridFS_test.txt" }
 error code: 11000
-error message: Could not store file: %s:%d:%sE11000 duplicate key error index: phpunit.fs.files.$filename_1%Sdup key: { : "/tmp/GridFS_test.txt" }
+error message: Could not store file: %s:%d:%s { : "/tmp/GridFS_test.txt" }
 error code: 11000
 
 ######################################

--- a/tests/generic/bug00320.phpt
+++ b/tests/generic/bug00320.phpt
@@ -57,9 +57,9 @@ $m = new_mongo_standalone("phpunit");
 # Saving files to GridFS
 ######################################
 [Saved file] New file id:file0
-error message: Could not store file: %s:%d:%sE11000 duplicate key error index: phpunit.fs.files.$filename_1%Sdup key: { : "/tmp/GridFS_test.txt" }
+error message: Could not store file: %s:%d:%s { : "/tmp/GridFS_test.txt" }
 error code: 11000
-error message: Could not store file: %s:%d:%sE11000 duplicate key error index: phpunit.fs.files.$filename_1%Sdup key: { : "/tmp/GridFS_test.txt" }
+error message: Could not store file: %s:%d:%s { : "/tmp/GridFS_test.txt" }
 error code: 11000
 array(1) {
   ["w"]=>

--- a/tests/generic/bug00372.phpt
+++ b/tests/generic/bug00372.phpt
@@ -46,6 +46,6 @@ try{
 }
 ?>
 --EXPECTF--
-error message: Could not store file: %s:%d:%sE11000 duplicate key error index: phpunit.test_prefix.files.$filename_1%Sdup key: { : "test.txt" }
+error message: Could not store file: %s:%d:%s { : "test.txt" }
 error code: 11000
 

--- a/tests/generic/bug00486.phpt
+++ b/tests/generic/bug00486.phpt
@@ -29,5 +29,5 @@ $gridfs->drop();
 ?>
 --EXPECTF--
 string(11) "./README.md"
-string(%d) "Could not store file:%sE11000 duplicate key error index: %s.fs.chunks.$files_id_1_n_1%Sdup key: { : 1, : 0 }"
+string(%d) "Could not store file:%s { : 1, : 0 }"
 string(11) "./README.md"

--- a/tests/generic/bug00690.phpt
+++ b/tests/generic/bug00690.phpt
@@ -21,4 +21,4 @@ catch ( Exception $e )
 
 ?>
 --EXPECTF--
-%s:%d:%sE11000 duplicate key error index: %s dup key: { : "hello%20London" }
+%s:%d:%s { : "hello%20London" }

--- a/tests/generic/mongo_batch_insert.phpt
+++ b/tests/generic/mongo_batch_insert.phpt
@@ -44,7 +44,7 @@ foreach ($c as $item) {
 ?>
 --EXPECTF--
 11000
-%s:%d:%S E11000 duplicate key error index: %s.c.$_id_%Sdup key: { : ObjectId('4cb4ab6d7addf98506010002') }
+%s:%d:%s { : ObjectId('4cb4ab6d7addf98506010002') }
 array(3) {
   ["_id"]=>
   object(MongoId)#%d (1) {

--- a/tests/generic/mongogridfs-storefile_error-001.phpt
+++ b/tests/generic/mongogridfs-storefile_error-001.phpt
@@ -20,5 +20,5 @@ try {
 }
 ?>
 --EXPECTF--
-string(%d) "Could not store file:%sE11000 duplicate key error index: %s.fs.chunks.$files_id_1_n_1%Sdup key: { : 1, : 0 }"
+string(%d) "Could not store file:%s { : 1, : 0 }"
 int(11000)

--- a/tests/generic/mongogridfs-storefile_error-002.phpt
+++ b/tests/generic/mongogridfs-storefile_error-002.phpt
@@ -20,4 +20,4 @@ try {
 }
 ?>
 --EXPECTF--
-Could not store file:%sE11000 duplicate key error index: %s.fs.chunks.$files_id_1_n_1%Sdup key: { : 1, : 0 }
+Could not store file:%s { : 1, : 0 }

--- a/tests/standalone/insert-duplicate-key.phpt
+++ b/tests/standalone/insert-duplicate-key.phpt
@@ -46,6 +46,6 @@ var_dump($tmp == $doc);
 <?php exit(0); ?>
 --EXPECTF--
 int(11000)
-%s:%d:%S E11000 duplicate key error index: %s.dupkey.$_id_%Sdup key: { : "DuplicateKeyError" }
+%s:%d:%s { : "DuplicateKeyError" }
 bool(true)
 ===DONE===

--- a/tests/standalone/mongoinsertbatch-004.phpt
+++ b/tests/standalone/mongoinsertbatch-004.phpt
@@ -91,7 +91,7 @@ array(3) {
       ["code"]=>
       int(11000)
       ["errmsg"]=>
-      string(%d) "%s: %s.%s.$_id_%Sdup key: { : "duplicatedid" }"
+      string(%d) "%s { : "duplicatedid" }"
     }
   }
   ["nInserted"]=>
@@ -113,7 +113,7 @@ array(3) {
       ["code"]=>
       int(11000)
       ["errmsg"]=>
-      string(%d) "%s: %s.%s.$_id_%Sdup key: { : "duplicatedid" }"
+      string(%d) "%s { : "duplicatedid" }"
     }
   }
   ["nInserted"]=>
@@ -135,7 +135,7 @@ array(3) {
       ["code"]=>
       int(11000)
       ["errmsg"]=>
-      string(%d) "%s: %s.%s.$_id_%Sdup key: { : "duplicatedid" }"
+      string(%d) "%s { : "duplicatedid" }"
     }
   }
   ["nInserted"]=>

--- a/tests/write/insert-duplicate-key.phpt
+++ b/tests/write/insert-duplicate-key.phpt
@@ -45,6 +45,6 @@ var_dump($tmp == $doc);
 ===DONE===
 <?php exit(0); ?>
 --EXPECTF--
-%s:%d: %s: test.dupkey.$_id_%Sdup key: { : "DuplicateKeyError" }
+%s:%d:%s { : "DuplicateKeyError" }
 bool(true)
 ===DONE===


### PR DESCRIPTION
Split out of https://github.com/mongodb/mongo-php-driver/pull/764
