### PR TITLE
PHP-1229: Fix file/chunk deletion for GridFS::remove() and justOne

### DIFF
--- a/tests/generic/bug01229.phpt
+++ b/tests/generic/bug01229.phpt
@@ -1,0 +1,42 @@
+--TEST--
+Test for PHP-1229: MongoGridFS::remove() ignores justOne option when deleting chunks
+--SKIPIF--
+<?php require_once "tests/utils/standalone.inc" ?>
+--FILE--
+<?php
+require_once "tests/utils/server.inc";
+
+$host = MongoShellServer::getStandaloneInfo();
+$mc = new MongoClient($host);
+
+$db = $mc->selectDB(dbname());
+$gridfs = $db->getGridFS(collname(__FILE__));
+$gridfs->drop();
+
+echo "Inserting 3 files\n";
+
+$gridfs->storeBytes('foo', array('x' => 1));
+$gridfs->storeBytes('bar', array('x' => 2));
+$gridfs->storeBytes('baz', array('x' => 2));
+
+printf("Counting fs.files documents: %d\n", $gridfs->count());
+printf("Counting fs.chunks documents: %d\n", $gridfs->chunks->count());
+
+echo "\nRemoving just one file matching {x:2}\n";
+
+$gridfs->remove(array('x' => 2), array('justOne' => true));
+
+printf("Counting fs.files documents: %d\n", $gridfs->count());
+printf("Counting fs.chunks documents: %d\n", $gridfs->chunks->count());
+
+?>
+===DONE===
+--EXPECT--
+Inserting 3 files
+Counting fs.files documents: 3
+Counting fs.chunks documents: 3
+
+Removing just one file matching {x:2}
+Counting fs.files documents: 2
+Counting fs.chunks documents: 2
+===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHP-1229

---

Previously, deleting a single file (with justOne) that was selected by some non-unique criteria could result in chunks from multiple files being deleted (because the initial files query was not limited).

Additionally, the final file deletion (after chunk removal) would re-use the original criteria. There is no guarantee that the same file would be matched in the second query, which could result in GridFS::remove() deleting file A's chunks but file B's file document.
