### PR TITLE
Fixed PHP-1505: negative files.length when storing file with size > 2GB in GridFS

### DIFF
--- a/gridfs/gridfs.c
+++ b/gridfs/gridfs.c
@@ -742,7 +742,7 @@ PHP_METHOD(MongoGridFS, storeFile)
 		char *buf;
 		zval *chunk_id = NULL;
 
-		int chunk_size = size-pos >= global_chunk_size || fp == 0 ? global_chunk_size : size-pos;
+		long chunk_size = size-pos >= global_chunk_size || fp == 0 ? global_chunk_size : size-pos;
 		buf = (char*)emalloc(chunk_size);
 
 		if (fp) {


### PR DESCRIPTION
I've *not* created a test, as it would mean shifting > 2GB around. I've verified it locally.