### PR TITLE
PHP-1505: Use long and size_t for GridFS file lengths

### DIFF
--- a/tests/generic/bug01505-001.phpt
+++ b/tests/generic/bug01505-001.phpt
@@ -1,0 +1,57 @@
+--TEST--
+Test for PHP-1505: GridFS file size should not be limited to 32-bit integer (file path)
+--DESCRIPTION--
+This test expects a 5GB file to use for inserting via MongoGridFS::storeFile().
+The file may be generated with `fallocate -l 5G /tmp/5gb`.
+--SKIPIF--
+skip Manual test
+<?php if (8 !== PHP_INT_SIZE) { die('skip Only for 64-bit platform'); } ?>
+<?php require_once "tests/utils/standalone.inc" ?>
+--FILE--
+<?php
+require_once "tests/utils/server.inc";
+
+$host = MongoShellServer::getStandaloneInfo();
+
+$mc = new MongoClient($host);
+$gridfs = $mc->selectDB(dbname())->getGridFS();
+$gridfs->drop();
+$id = $gridfs->storeFile('/tmp/5gb', array('chunkSize' => 4194304));
+$file = $gridfs->get($id);
+var_dump($file->file);
+
+?>
+==DONE==
+--CLEAN--
+<?php
+require_once "tests/utils/server.inc";
+
+$host = MongoShellServer::getStandaloneInfo();
+$mc = new MongoClient($host);
+$mc->selectDB(dbname())->getGridFS()->drop();
+
+?>
+--EXPECTF--
+array(6) {
+  ["_id"]=>
+  object(MongoId)#%d (%d) {
+    ["$id"]=>
+    string(24) "%x"
+  }
+  ["chunkSize"]=>
+  int(4194304)
+  ["filename"]=>
+  string(%d) "%s"
+  ["uploadDate"]=>
+  object(MongoDate)#%d (%d) {
+    ["sec"]=>
+    int(%d)
+    ["usec"]=>
+    int(%d)
+  }
+  ["length"]=>
+  int(5368709120)
+  ["md5"]=>
+  string(32) "%x"
+}
+==DONE==

--- a/tests/generic/bug01505-002.phpt
+++ b/tests/generic/bug01505-002.phpt
@@ -1,0 +1,58 @@
+--TEST--
+Test for PHP-1505: GridFS file size should not be limited to 32-bit integer (file resource)
+--DESCRIPTION--
+This test expects a 5GB file to use for inserting via MongoGridFS::storeFile().
+The file may be generated with `fallocate -l 5G /tmp/5gb`.
+--SKIPIF--
+skip Manual test
+<?php if (8 !== PHP_INT_SIZE) { die('skip Only for 64-bit platform'); } ?>
+<?php require_once "tests/utils/standalone.inc" ?>
+--FILE--
+<?php
+require_once "tests/utils/server.inc";
+
+$host = MongoShellServer::getStandaloneInfo();
+
+$mc = new MongoClient($host);
+$gridfs = $mc->selectDB(dbname())->getGridFS();
+$gridfs->drop();
+$fp = fopen('/tmp/5gb', 'r');
+$id = $gridfs->storeFile($fp, array('chunkSize' => 4194304));
+var_dump(fclose($fp));
+$file = $gridfs->get($id);
+var_dump($file->file);
+
+?>
+==DONE==
+--CLEAN--
+<?php
+require_once "tests/utils/server.inc";
+
+$host = MongoShellServer::getStandaloneInfo();
+$mc = new MongoClient($host);
+$mc->selectDB(dbname())->getGridFS()->drop();
+
+?>
+--EXPECTF--
+bool(true)
+array(5) {
+  ["_id"]=>
+  object(MongoId)#%d (%d) {
+    ["$id"]=>
+    string(24) "%x"
+  }
+  ["chunkSize"]=>
+  int(4194304)
+  ["uploadDate"]=>
+  object(MongoDate)#%d (%d) {
+    ["sec"]=>
+    int(%d)
+    ["usec"]=>
+    int(%d)
+  }
+  ["length"]=>
+  int(5368709120)
+  ["md5"]=>
+  string(32) "%x"
+}
+==DONE==

--- a/tests/utils/daemon.php
+++ b/tests/utils/daemon.php
@@ -8,7 +8,7 @@ function d($msg) {
 }
 
 
-$socket = stream_socket_server("tcp://0.0.0.0:8000", $errno, $errstr);
+$socket = stream_socket_server("tcp://localhost:8000", $errno, $errstr);
 if (!$socket) {
     echo "$errstr ($errno)\n";
     exit(1);


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHP-1505

Please run `fallocate -l 5G /tmp/5gb` to create a file for the regression test.