### PR TITLE
Bump make parallelism and suppress stdout in rebuild script

### DIFF
--- a/rebuild.sh
+++ b/rebuild.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
 export CFLAGS="-Wall -Wextra -Wdeclaration-after-statement -Wmissing-field-initializers -Wshadow -Wno-unused-parameter -ggdb3"
-phpize && ./configure --with-mongo-sasl && make clean && make -j 5 all && make install
+phpize > /dev/null && \
+./configure --with-mongo-sasl > /dev/null && \
+make clean && make all > /dev/null && make install


### PR DESCRIPTION
The stdout suppression is something I've adopted for PHPC's rebuild script, as it makes it easier to focus on compile warnings/errors.

Bumping the `-j` option as a matter of course.