### PR TITLE
PHP-1501: Rephrase exception message for unsupported/corrupt BSON type

### DIFF
--- a/tests/no-servers/bug01449-001.phpt
+++ b/tests/no-servers/bug01449-001.phpt
@@ -67,5 +67,5 @@ array(1) {
 }
 
 Testing invalid document:
-MongoException: type 0xfe not supported: 0a 00 00 00 fe 66 6f 6f 00
+MongoException: Detected unknown BSON type 0xfe for fieldname "foo". If this is an unsupported type and not data corruption, consider upgrading to the "mongodb" extension. BSON buffer: 0a 00 00 00 fe 66 6f 6f 00
 ===DONE===

--- a/tests/no-servers/bug01449-002.phpt
+++ b/tests/no-servers/bug01449-002.phpt
@@ -108,5 +108,5 @@ array(1) {
 }
 
 Testing invalid document:
-MongoException: type 0xfe not supported: 0a 00 00 00 fe 62 61 72 00
+MongoException: Detected unknown BSON type 0xfe for fieldname "bar". If this is an unsupported type and not data corruption, consider upgrading to the "mongodb" extension. BSON buffer: 0a 00 00 00 fe 62 61 72 00
 ===DONE===


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHP-1501

Per DRIVERS-281, this also adds field name (for the current nesting level) to the message.