### PR TITLE
array_init_size() is defined since PHP 5.3.0

### DIFF
--- a/collection.c
+++ b/collection.c
@@ -2779,11 +2779,7 @@ PHP_METHOD(MongoCollection, distinct)
 	}
 
 	if (zend_hash_find(Z_ARRVAL_P(tmp), "values", strlen("values") + 1, (void **)&values) == SUCCESS) {
-#ifdef array_init_size
 		array_init_size(return_value, zend_hash_num_elements(Z_ARRVAL_PP(values)));
-#else
-		array_init(return_value);
-#endif
 		zend_hash_copy(Z_ARRVAL_P(return_value), Z_ARRVAL_PP(values), (copy_ctor_func_t) zval_add_ref, NULL, sizeof(zval *));
 	} else {
 		RETVAL_FALSE;


### PR DESCRIPTION
This looks like leftover code from when we still supported PHP 5.2.

See: php/php-src@7da75d81e7993e8c0dd56edf2614be4ce69970a4