### PR TITLE
PHP-1510: Fix tests for legacy opcode rerouting

### DIFF
--- a/collection.c
+++ b/collection.c
@@ -378,11 +378,13 @@ static zval* append_getlasterror(zval *coll, mongo_buffer *buf, zval *options, m
 		php_error_docref(NULL TSRMLS_CC, E_DEPRECATED, "The 'MongoCursor::$timeout' static property is deprecated, please call MongoCursor->timeout() instead");
 	}
 
-	/* Get the default value for journalling */
-	fsync = link->servers->options.default_fsync;
-	journal = link->servers->options.default_journal;
-
 	/* Read the default_* properties from the link */
+	if (link->servers->options.default_fsync != -1) {
+		fsync = link->servers->options.default_fsync;
+	}
+	if (link->servers->options.default_journal != -1) {
+		journal = link->servers->options.default_journal;
+	}
 	if (link->servers->options.default_w != -1) {
 		w = link->servers->options.default_w;
 	}

--- a/tests/standalone/bug01085-001.phpt
+++ b/tests/standalone/bug01085-001.phpt
@@ -8,14 +8,14 @@ Test for PHP-1085: w=0 returns unexpected exception on failure (socketTimeoutMS 
 
 require_once "tests/utils/server.inc";
 
-function assertFalse($value) {
+function assertTrue($value) {
     if ( ! is_bool($value)) {
         printf("Expected boolean type but received %s\n", gettype($value));
         return;
     }
 
-    if ($value !== false) {
-        echo "Expected boolean false but received boolean true\n";
+    if ($value !== true) {
+        echo "Expected boolean true but received boolean false\n";
     }
 }
 
@@ -34,7 +34,7 @@ for ($i = 0; $i < 10; ++$i) {
         array('x' => $i, 'y' => str_repeat('a', 4*1024*1024)),
         array('w' => 0)
     );
-    assertFalse($retval);
+    assertTrue($retval);
 }
 
 echo "Testing update() with w=0\n";
@@ -44,7 +44,7 @@ $retval = $collection->update(
     array('$set' => array('y' => 1)),
     array('w' => 0)
 );
-assertFalse($retval);
+assertTrue($retval);
 
 echo "Testing remove() with w=0\n";
 
@@ -52,7 +52,7 @@ $retval = $collection->remove(
     array('$where' => 'sleep(1) && false'),
     array('w' => 0)
 );
-assertFalse($retval);
+assertTrue($retval);
 
 echo "Testing update() with w=1\n";
 

--- a/tests/standalone/bug01085-002.phpt
+++ b/tests/standalone/bug01085-002.phpt
@@ -8,14 +8,14 @@ Test for PHP-1085: w=0 returns unexpected exception on failure (socketTimeoutMS 
 
 require_once "tests/utils/server.inc";
 
-function assertFalse($value) {
+function assertTrue($value) {
     if ( ! is_bool($value)) {
         printf("Expected boolean type but received %s\n", gettype($value));
         return;
     }
 
-    if ($value !== false) {
-        echo "Expected boolean false but received boolean true\n";
+    if ($value !== true) {
+        echo "Expected boolean true but received boolean false\n";
     }
 }
 
@@ -32,7 +32,7 @@ for ($i = 0; $i < 10; ++$i) {
         array('x' => $i, 'y' => str_repeat('a', 4*1024*1024)),
         array('w' => 0, 'socketTimeoutMS' => 1)
     );
-    assertFalse($retval);
+    assertTrue($retval);
 }
 
 echo "Testing update() with w=0\n";
@@ -42,7 +42,7 @@ $retval = $collection->update(
     array('$set' => array('y' => 1)),
     array('w' => 0, 'socketTimeoutMS' => 1)
 );
-assertFalse($retval);
+assertTrue($retval);
 
 echo "Testing remove() with w=0\n";
 
@@ -50,7 +50,7 @@ $retval = $collection->remove(
     array('$where' => 'sleep(1) && false'),
     array('w' => 0, 'socketTimeoutMS' => 1)
 );
-assertFalse($retval);
+assertTrue($retval);
 
 echo "Testing update() with w=1\n";
 

--- a/tests/standalone/mongoclient-connection-options-fsync-2.6.phpt
+++ b/tests/standalone/mongoclient-connection-options-fsync-2.6.phpt
@@ -47,12 +47,11 @@ dump_writeConcern($mn);
 
 echo "Setting it to false, per-query, and w=0 to force no-gle\n";
 $doc = array("doc" => "ument");
+printLogs(MongoLog::IO, MongoLog::FINE, '/is_gle_op/');
 $mc->test->bug572->insert($doc, array("fsync" => false, "w" => 0));
-dump_writeConcern($mn);
 $mc->test->bug572->update(array("_id" => $doc["_id"]), array("updated" => "doc"), array("fsync" => false, "w" => 0));
-dump_writeConcern($mn);
 $mc->test->bug572->remove(array("_id" => $doc["_id"]), array("fsync" => false, "w" => 0));
-dump_writeConcern($mn);
+MongoLog::setLevel(MongoLog::NONE);
 
 $mc = new MongoClient($host, array("fsync" => false), array("context" => $ctx));
 
@@ -78,12 +77,11 @@ $mc = new MongoClient($host, array("fsync" => false, "w" => 0), array("context" 
 
 echo "Fsync disabled by default, and gle\n";
 $doc = array("doc" => "ument");
+printLogs(MongoLog::IO, MongoLog::FINE, '/is_gle_op/');
 $mc->test->bug572->insert($doc);
-dump_writeConcern($mn);
 $mc->test->bug572->update(array("_id" => $doc["_id"]), array("updated" => "doc"));
-dump_writeConcern($mn);
 $mc->test->bug572->remove(array("_id" => $doc["_id"]));
-dump_writeConcern($mn);
+MongoLog::setLevel(MongoLog::NONE);
 
 echo "Setting it to true, per-query, with gle=0\n";
 $doc = array("doc" => "ument");
@@ -135,24 +133,9 @@ array(2) {
   int(1)
 }
 Setting it to false, per-query, and w=0 to force no-gle
-array(2) {
-  ["fsync"]=>
-  bool(false)
-  ["w"]=>
-  int(0)
-}
-array(2) {
-  ["fsync"]=>
-  bool(false)
-  ["w"]=>
-  int(0)
-}
-array(2) {
-  ["fsync"]=>
-  bool(false)
-  ["w"]=>
-  int(0)
-}
+is_gle_op: no
+is_gle_op: no
+is_gle_op: no
 Fsync disabled by default
 array(2) {
   ["fsync"]=>
@@ -192,24 +175,9 @@ array(2) {
   int(1)
 }
 Fsync disabled by default, and gle
-array(2) {
-  ["fsync"]=>
-  bool(false)
-  ["w"]=>
-  int(0)
-}
-array(2) {
-  ["fsync"]=>
-  bool(false)
-  ["w"]=>
-  int(0)
-}
-array(2) {
-  ["fsync"]=>
-  bool(false)
-  ["w"]=>
-  int(0)
-}
+is_gle_op: no
+is_gle_op: no
+is_gle_op: no
 Setting it to true, per-query, with gle=0
 array(2) {
   ["fsync"]=>

--- a/tests/standalone/mongoclient-connection-options-journal-2.6.phpt
+++ b/tests/standalone/mongoclient-connection-options-journal-2.6.phpt
@@ -48,12 +48,11 @@ dump_writeConcern($mn);
 
 echo "Setting it to false, per-query, and w=0 to force no-gle\n";
 $doc = array("doc" => "ument");
+printLogs(MongoLog::IO, MongoLog::FINE, '/is_gle_op/');
 $mc->test->bug572->insert($doc, array("j" => false, "w" => 0));
-dump_writeConcern($mn);
 $mc->test->bug572->update(array("_id" => $doc["_id"]), array("updated" => "doc"), array("j" => false, "w" => 0));
-dump_writeConcern($mn);
 $mc->test->bug572->remove(array("_id" => $doc["_id"]), array("j" => false, "w" => 0));
-dump_writeConcern($mn);
+MongoLog::setLevel(MongoLog::NONE);
 
 $mc = new MongoClient($host, array("journal" => false), array("context" => $ctx));
 
@@ -79,12 +78,11 @@ $mc = new MongoClient($host, array("journal" => false, "w" => 0), array("context
 
 echo "journal disabled by default, and gle\n";
 $doc = array("doc" => "ument");
+printLogs(MongoLog::IO, MongoLog::FINE, '/is_gle_op/');
 $mc->test->bug572->insert($doc);
-dump_writeConcern($mn);
 $mc->test->bug572->update(array("_id" => $doc["_id"]), array("updated" => "doc"));
-dump_writeConcern($mn);
 $mc->test->bug572->remove(array("_id" => $doc["_id"]));
-dump_writeConcern($mn);
+MongoLog::setLevel(MongoLog::NONE);
 
 echo "Setting it to true, per-query, with gle=0\n";
 $doc = array("doc" => "ument");
@@ -136,24 +134,9 @@ array(2) {
   int(1)
 }
 Setting it to false, per-query, and w=0 to force no-gle
-array(2) {
-  ["j"]=>
-  bool(false)
-  ["w"]=>
-  int(0)
-}
-array(2) {
-  ["j"]=>
-  bool(false)
-  ["w"]=>
-  int(0)
-}
-array(2) {
-  ["j"]=>
-  bool(false)
-  ["w"]=>
-  int(0)
-}
+is_gle_op: no
+is_gle_op: no
+is_gle_op: no
 journal disabled by default
 array(2) {
   ["j"]=>
@@ -193,24 +176,9 @@ array(2) {
   int(1)
 }
 journal disabled by default, and gle
-array(2) {
-  ["j"]=>
-  bool(false)
-  ["w"]=>
-  int(0)
-}
-array(2) {
-  ["j"]=>
-  bool(false)
-  ["w"]=>
-  int(0)
-}
-array(2) {
-  ["j"]=>
-  bool(false)
-  ["w"]=>
-  int(0)
-}
+is_gle_op: no
+is_gle_op: no
+is_gle_op: no
 Setting it to true, per-query, with gle=0
 array(2) {
   ["j"]=>


### PR DESCRIPTION
 * https://jira.mongodb.org/browse/PHP-1510
 * https://jira.mongodb.org/browse/PHP-1511

My mistake for not catching these test failures in #876. Please see full commit messages for an explanation of changes.

While sorting these out, I also noticed an irregularity with `append_getlasterror()` and opened [PHPC-1511](https://jira.mongodb.org/browse/PHP-1511). I don't believe this affects anything, since the function would not have been called if `is_gle_op()` returned false, but the previous logic looked incorrect nevertheless.

**Note**: This was opened against the wrong branch. Will be merged to `v1.6`.