### PR TITLE
Fix check long size on Unix systems

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -3,6 +3,9 @@ PHP_ARG_ENABLE(mongo, whether to enable Mongo extension,
 
 PHP_MONGO_CFLAGS="-I@ext_builddir@/util"
 
+AC_CHECK_SIZEOF([long])
+AC_CHECK_SIZEOF([size_t])
+
 AC_DEFUN([MONGO_ADD_DIR], [
   PHP_ADD_BUILD_DIR([$ext_builddir/$1], 1)
   PHP_ADD_INCLUDE([$ext_builddir/$1])

--- a/config.m4
+++ b/config.m4
@@ -4,7 +4,6 @@ PHP_ARG_ENABLE(mongo, whether to enable Mongo extension,
 PHP_MONGO_CFLAGS="-I@ext_builddir@/util"
 
 AC_CHECK_SIZEOF([long])
-AC_CHECK_SIZEOF([size_t])
 
 AC_DEFUN([MONGO_ADD_DIR], [
   PHP_ADD_BUILD_DIR([$ext_builddir/$1], 1)

--- a/php_mongo.c
+++ b/php_mongo.c
@@ -151,7 +151,11 @@ static PHP_INI_MH(OnUpdateNativeLong)
 
 	if (new_value && is_numeric_string(new_value, new_value_length, &converted_val, NULL, 0) == IS_LONG) {
 		if (converted_val != 0) {
-			php_error_docref(NULL TSRMLS_CC, E_CORE_ERROR, "To prevent data corruption, you are not allowed to turn on the mongo.native_long setting on 32-bit platforms");
+			php_error_docref(NULL TSRMLS_CC, E_CORE_ERROR, "To prevent data corruption, you are not allowed to turn on the mongo.native_long setting on 32-bit platforms."
+#if WIN32 || _WIN64
+			" And this is Windows build limitation."
+#endif
+			);
 		}
 		return SUCCESS;
 	}


### PR DESCRIPTION
- add autoconf checks for long and size_t - SIZEOF_LONG not defined in config.h
- add remark about Windows build - long always 4 bytes on 32 & 64 bit build