### PR TITLE
PHP-1528: Ensure libraries are linked when building with SSL

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -1,5 +1,7 @@
 PHP_ARG_ENABLE(mongo, whether to enable Mongo extension,
 [  --enable-mongo          Enable the MongoDB extension])
+PHP_ARG_WITH(openssl-dir, Build with OpenSSL support,
+[  --with-openssl-dir[=DIR]    Mongo: Include OpenSSL support], yes, no)
 
 PHP_MONGO_CFLAGS="-I@ext_builddir@/util"
 
@@ -23,6 +25,12 @@ if test "$PHP_MONGO" != "no"; then
   MONGO_ADD_DIR(contrib)
   MONGO_ADD_DIR(mcon)
   MONGO_ADD_DIR(mcon/contrib)
+
+  test -z "$PHP_OPENSSL" && PHP_OPENSSL=no
+
+  if test "$PHP_OPENSSL" != "no" || test "$PHP_OPENSSL_DIR" != "no"; then
+    PHP_SETUP_OPENSSL(MONGO_SHARED_LIBADD)
+  fi
 
   PHP_ADD_MAKEFILE_FRAGMENT([$ext_srcdir/Makefile.servers])
 
@@ -142,5 +150,8 @@ if test "$PHP_MONGO_SASL" != "no"; then
   ], [
     -L$MONGO_SASL_DIR/$PHP_LIBDIR
   ])
+fi
+
+if test "$PHP_MONGO" != "no"; then
   PHP_SUBST(MONGO_SHARED_LIBADD)
 fi

--- a/config.m4
+++ b/config.m4
@@ -30,6 +30,7 @@ if test "$PHP_MONGO" != "no"; then
 
   if test "$PHP_OPENSSL" != "no" || test "$PHP_OPENSSL_DIR" != "no"; then
     PHP_SETUP_OPENSSL(MONGO_SHARED_LIBADD)
+    AC_DEFINE(HAVE_MONGO_OPENSSL, 1, [Mongo OpenSSL support])
   fi
 
   PHP_ADD_MAKEFILE_FRAGMENT([$ext_srcdir/Makefile.servers])

--- a/contrib/php-ssl.c
+++ b/contrib/php-ssl.c
@@ -25,7 +25,7 @@
 # include <php_config.h>
 #endif
 
-#ifdef HAVE_OPENSSL_EXT
+#ifdef HAVE_MONGO_OPENSSL
 #include "php-ssl.h"
 
 int php_mongo_matches_wildcard_name(const char *subjectname, const char *certname) /* {{{ */
@@ -233,5 +233,5 @@ time_t php_mongo_asn1_time_to_time_t(ASN1_UTCTIME * timestr TSRMLS_DC) /* {{{ */
 }
 /* }}} */
 
-#endif /* HAVE_OPENSSL_EXT */
+#endif /* HAVE_MONGO_OPENSSL */
 

--- a/contrib/php-ssl.h
+++ b/contrib/php-ssl.h
@@ -27,7 +27,7 @@
 # include <php_config.h>
 #endif
 
-#ifdef HAVE_OPENSSL_EXT
+#ifdef HAVE_MONGO_OPENSSL
 
 #include "php.h"
 #include <openssl/evp.h>
@@ -39,6 +39,6 @@ int php_mongo_matches_san_list(X509 *peer, const char *subject_name);
 int php_mongo_matches_common_name(X509 *peer, const char *subject_name TSRMLS_DC);
 time_t php_mongo_asn1_time_to_time_t(ASN1_UTCTIME * timestr TSRMLS_DC);
 
-#endif /* HAVE_OPENSSL_EXT */
+#endif /* HAVE_MONGO_OPENSSL */
 #endif 
 

--- a/io_stream.c
+++ b/io_stream.c
@@ -30,7 +30,7 @@
 # include <php_config.h>
 #endif
 
-#ifdef HAVE_OPENSSL_EXT
+#ifdef HAVE_MONGO_OPENSSL
 # include "contrib/php-ssl.h"
 #endif
 
@@ -63,7 +63,7 @@
 extern zend_class_entry *mongo_ce_ConnectionException;
 ZEND_EXTERN_MODULE_GLOBALS(mongo)
 
-#ifdef HAVE_OPENSSL_EXT
+#ifdef HAVE_MONGO_OPENSSL
 # if PHP_VERSION_ID < 50600
 int php_mongo_verify_hostname(mongo_server_def *server, X509 *cert TSRMLS_DC)
 {
@@ -180,7 +180,7 @@ void* php_mongo_io_stream_connect(mongo_con_manager *manager, mongo_server_def *
 				return NULL;
 			}
 		} else if (stream->context) {
-#ifdef HAVE_OPENSSL_EXT
+#ifdef HAVE_MONGO_OPENSSL
 			zval **zcert;
 
 			if (php_stream_context_get_option(stream->context, "ssl", "peer_certificate", &zcert) == SUCCESS && Z_TYPE_PP(zcert) == IS_RESOURCE) {
@@ -236,7 +236,7 @@ void* php_mongo_io_stream_connect(mongo_con_manager *manager, mongo_server_def *
 					mongo_manager_log(manager, MLOG_CON, MLOG_WARN, "Certificate expiration checks disabled");
 				}
 			}
-#endif /* HAVE_OPENSSL_EXT */
+#endif /* HAVE_MONGO_OPENSSL */
 			mongo_manager_log(manager, MLOG_CON, MLOG_INFO, "stream_connect: Establish SSL for %s:%d", server->host, server->port);
 		}
 	} else {

--- a/php_mongo.c
+++ b/php_mongo.c
@@ -259,7 +259,7 @@ PHP_MINIT_FUNCTION(mongo)
 	REGISTER_LONG_CONSTANT("MONGO_STREAMS", 1, CONST_PERSISTENT);
 	REGISTER_LONG_CONSTANT("MONGO_SUPPORTS_STREAMS", 1, CONST_PERSISTENT);
 
-#if HAVE_OPENSSL_EXT
+#if HAVE_MONGO_OPENSSL
 	REGISTER_LONG_CONSTANT("MONGO_SUPPORTS_SSL", 1, CONST_PERSISTENT);
 #else
 	REGISTER_LONG_CONSTANT("MONGO_SUPPORTS_SSL", 0, CONST_PERSISTENT);
@@ -426,7 +426,7 @@ PHP_MINFO_FUNCTION(mongo)
 	php_info_print_table_row(2, "Version", PHP_MONGO_VERSION);
 	php_info_print_table_row(2, "Streams Support", "enabled");
 
-#if HAVE_OPENSSL_EXT
+#if HAVE_MONGO_OPENSSL
 	php_info_print_table_row(2, "SSL Support", "enabled");
 #endif
 
@@ -434,7 +434,7 @@ PHP_MINFO_FUNCTION(mongo)
 	php_info_print_table_row(2, "MONGODB-CR", "enabled");
 	php_info_print_table_row(2, "SCRAM-SHA-1", "enabled");
 
-#if HAVE_OPENSSL_EXT
+#if HAVE_MONGO_OPENSSL
 	php_info_print_table_row(2, "MONGODB-X509", "enabled");
 #else
 	php_info_print_table_row(2, "MONGODB-X509", "disabled");


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHP-1528

This alters `config.m4` so that we only call `PHP_SUBST(MONGO_SHARED_LIBADD)` once at the end of configuration (after SSL and SASL may have been configured).