### PR TITLE
PHP-1529: Fix undefined symbols from contrib/php-ssl.c

### DIFF
--- a/contrib/php-ssl.c
+++ b/contrib/php-ssl.c
@@ -18,6 +18,9 @@
   +----------------------------------------------------------------------+
 */
 
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
 
 #ifdef PHP_WIN32
 # include "config.w32.h"

--- a/contrib/php-ssl.h
+++ b/contrib/php-ssl.h
@@ -21,6 +21,10 @@
 #ifndef MONGO_CONTRIB_SSL_H
 #define MONGO_CONTRIB_SSL_H
 
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
 #ifdef PHP_WIN32
 # include "config.w32.h"
 #else

--- a/io_stream.c
+++ b/io_stream.c
@@ -30,10 +30,6 @@
 # include <php_config.h>
 #endif
 
-#ifdef HAVE_MONGO_OPENSSL
-# include "contrib/php-ssl.h"
-#endif
-
 #include <php.h>
 #include <main/php_streams.h>
 #include <main/php_network.h>
@@ -48,6 +44,10 @@
 
 #ifdef HAVE_CONFIG_H
 # include "config.h"
+#endif
+
+#ifdef HAVE_MONGO_OPENSSL
+# include "contrib/php-ssl.h"
 #endif
 
 #if HAVE_MONGO_SASL


### PR DESCRIPTION
https://jira.mongodb.org/browse/PHP-1529

Supersedes https://github.com/mongodb/mongo-php-driver-legacy/pull/883